### PR TITLE
Adjusting script arguments to generate better output

### DIFF
--- a/oomkill/oomkill_job.yaml
+++ b/oomkill/oomkill_job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: oom-kill-job3
+  name: oom-kill-job
 spec:
   ttlSecondsAfterFinished: 3600
   backoffLimit: 0
@@ -9,11 +9,11 @@ spec:
     spec:
       containers:
       - args:
-        - 75Mi
+        - 40Mi
         - "0"
-        - 30Mi
-        - "80"
-        - "1"
+        - 80Mi
+        - "400"
+        - "2"
         image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/memory-eater:1.0
         imagePullPolicy: Always
         name: memory-eater
@@ -23,3 +23,5 @@ spec:
           requests:
             memory: 100Mi
       restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/arch: amd64


### PR DESCRIPTION
I feel this works better with the Robusta UI because it gives the runner time to collect Job metrics (which only show up after 5 min).
Also added the `nodeSelector` since this container does not run on `arm64` nodes.

This is how the memory graph looks on Grafana
<img width="1300" alt="image" src="https://github.com/robusta-dev/kubernetes-demos/assets/17923899/17e892d8-0cd6-410a-b414-264e56e60f18">
