### PR TITLE
Keep oomkill job around for longer after oom'ing

### DIFF
--- a/oomkill/oomkill_job.yaml
+++ b/oomkill/oomkill_job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: analytics-exporter
 spec:
-  ttlSecondsAfterFinished: 3600
+  ttlSecondsAfterFinished: 36000
   backoffLimit: 0
   template:
     spec:


### PR DESCRIPTION
We need this for the HolmesGPT test framework which can run for a few hours and tests the same scenarios repeatedly