### PR TITLE
fix: restore config dictionary in user-api to fix CrashLoopBackOff

### DIFF
--- a/user-api/app.py
+++ b/user-api/app.py
@@ -2,7 +2,7 @@ from flask import Flask, jsonify
 
 app = Flask(__name__)
 
-config = None
+config = {"host": "0.0.0.0", "port": 5000}
 
 host = config["host"]
 port = config["port"]


### PR DESCRIPTION
## Problem
The `user-api` deployment in the `users` namespace is in **CrashLoopBackOff** with 6+ restarts.

### Error
```
TypeError: 'NoneType' object is not subscriptable
File "/app/app.py", line 7, in <module>
    host = config["host"]
```

## Root Cause
Commit b352481 ("We don't need config, for sure!") changed `config` from a dictionary to `None`:

```diff
- config = {"host": "0.0.0.0", "port": 5000}
+ config = None
```

This causes the application to crash immediately on startup since `config["host"]` fails when `config` is `None`.

## Fix
This PR restores the config dictionary with the required `host` and `port` values.

## Testing
After merging, redeploy the `user-api` with the updated image (v3) to resolve the CrashLoopBackOff.