### PR TITLE
fix: restore config dictionary to fix user-api startup crash

### DIFF
--- a/user-api/app.py
+++ b/user-api/app.py
@@ -2,7 +2,7 @@ from flask import Flask, jsonify
 
 app = Flask(__name__)
 
-config = None
+config = {"host": "0.0.0.0", "port": 5000}
 
 host = config["host"]
 port = config["port"]


### PR DESCRIPTION
## Problem

The `user-api` deployment is in **CrashLoopBackOff** due to a `TypeError` on startup:

```
TypeError: 'NoneType' object is not subscriptable
  File "/app/app.py", line 7, in <module>
    host = config["host"]
```

## Root Cause

Commit b352481 ("We don't need config, for sure!") changed:
```python
config = {"host": "0.0.0.0", "port": 5000}
```
to:
```python
config = None
```

This causes the application to crash immediately when trying to access `config["host"]`.

## Fix

This PR restores the config dictionary with the correct host and port values.

## Testing

After merging, rebuild the container image and redeploy. The pod should start successfully and pass health checks.