### PR TITLE
Add ticketing-incident-demo for incident.io / Holmes first-responder demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ To get notifications like below, install [Robusta](https://github.com/robusta-de
 # Advanced Scenarios
 
 <details>
+<summary>Ticketing Platform — Microservice DB Misconfiguration (incident.io / Holmes demo)</summary>
+
+A small ticketing-company environment: three services (`seat-selection`, `booking`, `payment`) sharing one PostgreSQL database. The `seat-selection` service was shipped with a wrong `DB_HOST` and crash-loops, so customers can't buy tickets — an alert that looks low severity but is an urgent, revenue-impacting incident.
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/robusta-dev/kubernetes-demos/main/ticketing-incident-demo/manifest.yaml
+```
+
+Designed so an AI first responder (HolmesGPT) can find the root cause with no prior knowledge of the environment. See [`ticketing-incident-demo/`](./ticketing-incident-demo) for the full scenario and the Grafana test-alert payload.
+</details>
+
+
+<details>
 <summary>Correlate Changes and Errors</summary>
 
 Deploy a healthy pod. Then break it. 

--- a/ticketing-incident-demo/Dockerfile
+++ b/ticketing-incident-demo/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application
+COPY app ./app
+
+# Service role (seat-selection | booking | payment) is set via SERVICE_NAME env.
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ticketing-incident-demo/README.md
+++ b/ticketing-incident-demo/README.md
@@ -1,0 +1,96 @@
+# Ticketing platform — incident.io / Holmes first-responder demo
+
+A small, realistic microservices environment for demoing **HolmesGPT as the first
+responder** in an incident.io workflow.
+
+## Scenario
+
+We are a ticketing company. The platform has three services that share one
+PostgreSQL database:
+
+```
+seat-selection ─┐
+booking ────────┼──▶  ticketing-db (PostgreSQL)
+payment ────────┘
+```
+
+The `seat-selection` service was updated and the new revision shipped with a
+**wrong database host** (`DB_HOST: ticketing-db-prod`, which does not resolve).
+On startup the service cannot reach the database, so it **crash-loops**
+(`CrashLoopBackOff` → `KubePodCrashLooping`). `booking` and `payment` use the
+correct host and stay healthy.
+
+Because `seat-selection` is on the purchase critical path, **no customer can pick
+a seat or buy a ticket** — a low-severity alert that is actually an urgent,
+revenue-impacting incident.
+
+## How Holmes finds the root cause (no prior knowledge of the env)
+
+Everything Holmes needs is in-cluster:
+
+1. **Logs** — `kubectl logs deploy/seat-selection -n ticketing` shows a real
+   PostgreSQL error naming the bad host
+   (`could not translate host name "ticketing-db-prod" to address`) ending in a
+   `FATAL` line.
+2. **Deployment spec** — `kubectl get deploy seat-selection -n ticketing -o yaml`
+   shows `DB_HOST: ticketing-db-prod`.
+3. **Healthy siblings as a diff** — `booking` and `payment` use `DB_HOST:
+   ticketing-db`, so the discrepancy is obvious.
+4. **Business impact** — descriptive names + labels (`business-criticality:
+   tier-1`, `app.kubernetes.io/part-of: ticketing-platform`, `team: checkout`)
+   let Holmes infer the revenue impact and escalate to Urgent.
+
+The fix is a one-line change Holmes can open as a PR: in `manifest.yaml`, change
+the `seat-selection` container's `DB_HOST` from `ticketing-db-prod` to
+`ticketing-db`.
+
+## Deploying
+
+The container image is prebuilt. Just apply the manifest:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/robusta-dev/kubernetes-demos/main/ticketing-incident-demo/manifest.yaml
+```
+
+Verify:
+
+```
+kubectl get pods -n ticketing
+# seat-selection-*   CrashLoopBackOff
+# booking-*          Running
+# payment-*          Running
+# ticketing-db-*     Running
+```
+
+Cleanup:
+
+```
+kubectl delete -f https://raw.githubusercontent.com/robusta-dev/kubernetes-demos/main/ticketing-incident-demo/manifest.yaml
+```
+
+## Firing the alert (Stage #3)
+
+See [`grafana-test-alert.md`](./grafana-test-alert.md) for the exact Summary,
+Description, Labels, and Runbook URL to paste into Grafana's **Test contact
+point**, which creates the incident in incident.io.
+
+## Building the image (maintainers)
+
+```
+./build.sh   # builds + pushes us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+```
+
+The same image runs all three roles; the role is chosen by the `SERVICE_NAME`
+environment variable (`seat-selection` | `booking` | `payment`).
+
+## Reskinning to another business flavor
+
+The failure mechanism (bad `DB_HOST` env var → crash loop) is identical for every
+flavor — only the names, labels, and alert text change. To reskin, rename the
+services and database in `manifest.yaml` and update `grafana-test-alert.md`:
+
+| Flavor       | Crashing service | Other services        | Database     | Impact when crashing            |
+|--------------|------------------|-----------------------|--------------|---------------------------------|
+| Ticketing    | `seat-selection` | `booking`, `payment`  | `ticketing-db` | Customers can't buy tickets     |
+| E-commerce   | `checkout`       | `cart`, `catalog`     | `orders-db`    | Customers can't complete orders |
+| Banking      | `transfers`      | `accounts`, `ledger`  | `ledger-db`    | Customers can't move money      |

--- a/ticketing-incident-demo/README.md
+++ b/ticketing-incident-demo/README.md
@@ -77,7 +77,7 @@ point**, which creates the incident in incident.io.
 ## Building the image (maintainers)
 
 ```
-./build.sh   # builds + pushes us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+./build.sh   # builds + pushes europe-docker.pkg.dev/robusta-development/kubernetes-demos/ticketing-service:v1
 ```
 
 The same image runs all three roles; the role is chosen by the `SERVICE_NAME`

--- a/ticketing-incident-demo/app/db.py
+++ b/ticketing-incident-demo/app/db.py
@@ -1,0 +1,81 @@
+"""Database connection helpers for the ticketing platform services.
+
+All services connect to the same PostgreSQL instance using the standard
+DB_* environment variables. On startup a service must be able to reach the
+database - if it cannot, the process exits so Kubernetes restarts it (and the
+problem becomes visible as a CrashLoopBackOff instead of silently serving
+errors).
+"""
+
+import logging
+import os
+import time
+
+import psycopg2
+
+logger = logging.getLogger("ticketing")
+
+# Database connection settings (provided via env, see manifest.yaml).
+DB_HOST = os.getenv("DB_HOST")
+DB_PORT = os.getenv("DB_PORT", "5432")
+DB_NAME = os.getenv("DB_NAME")
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+# How long we try to reach the database on boot before giving up.
+CONNECT_MAX_ATTEMPTS = int(os.getenv("DB_CONNECT_MAX_ATTEMPTS", "10"))
+CONNECT_RETRY_SECONDS = int(os.getenv("DB_CONNECT_RETRY_SECONDS", "3"))
+
+
+def connect():
+    """Open a new connection to PostgreSQL using the DB_* settings."""
+    return psycopg2.connect(
+        host=DB_HOST,
+        port=DB_PORT,
+        dbname=DB_NAME,
+        user=DB_USER,
+        password=DB_PASSWORD,
+        connect_timeout=5,
+    )
+
+
+def wait_for_database():
+    """Block until the database is reachable, or exit the process.
+
+    A service that cannot reach its database cannot serve customers, so there
+    is no point in coming up degraded. We retry a handful of times to ride out
+    a database restart, then fail hard with a clear log line.
+    """
+    for attempt in range(1, CONNECT_MAX_ATTEMPTS + 1):
+        try:
+            logger.info(
+                "Connecting to ticketing database at %s:%s/%s (attempt %d/%d)",
+                DB_HOST,
+                DB_PORT,
+                DB_NAME,
+                attempt,
+                CONNECT_MAX_ATTEMPTS,
+            )
+            conn = connect()
+            conn.close()
+            logger.info("Successfully connected to ticketing database at %s:%s", DB_HOST, DB_PORT)
+            return
+        except Exception as exc:  # noqa: BLE001 - we want to log the real driver error
+            logger.error(
+                "Could not connect to ticketing database at %s:%s - %s",
+                DB_HOST,
+                DB_PORT,
+                exc,
+            )
+            if attempt < CONNECT_MAX_ATTEMPTS:
+                time.sleep(CONNECT_RETRY_SECONDS)
+
+    logger.critical(
+        "FATAL: giving up after %d attempts - database %s:%s/%s is unreachable. "
+        "Check the DB_HOST environment variable.",
+        CONNECT_MAX_ATTEMPTS,
+        DB_HOST,
+        DB_PORT,
+        DB_NAME,
+    )
+    raise SystemExit(1)

--- a/ticketing-incident-demo/app/main.py
+++ b/ticketing-incident-demo/app/main.py
@@ -1,0 +1,110 @@
+"""Ticketing platform service.
+
+A single FastAPI codebase that runs as one of three roles in the ticketing
+platform, selected by the SERVICE_NAME environment variable:
+
+  * seat-selection - holds/returns available seats for an event
+  * booking        - creates a booking for selected seats
+  * payment        - charges for a booking
+
+Every role talks to the same PostgreSQL database. The connection is verified on
+startup; if the database is unreachable the process exits (see app/db.py).
+"""
+
+import logging
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException
+
+from app import db
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+logger = logging.getLogger("ticketing")
+
+SERVICE_NAME = os.getenv("SERVICE_NAME", "seat-selection")
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    logger.info("Starting %s service", SERVICE_NAME)
+    # Fail fast if we cannot reach the database - the service is useless without it.
+    db.wait_for_database()
+    logger.info("%s service is ready", SERVICE_NAME)
+    yield
+    logger.info("Shutting down %s service", SERVICE_NAME)
+
+
+app = FastAPI(title=f"ticketing-{SERVICE_NAME}", lifespan=lifespan)
+
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/readyz")
+def readyz():
+    try:
+        conn = db.connect()
+        conn.close()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=503, detail=f"database unavailable: {exc}")
+    return {"status": "ready", "service": SERVICE_NAME}
+
+
+@app.get("/seats")
+def list_seats(event_id: int):
+    """seat-selection role: list available seats for an event."""
+    conn = db.connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, row_label, seat_number "
+                "FROM seats WHERE event_id = %s AND status = 'available' "
+                "ORDER BY row_label, seat_number",
+                (event_id,),
+            )
+            seats = [
+                {"id": row[0], "row": row[1], "seat": row[2]} for row in cur.fetchall()
+            ]
+        return {"event_id": event_id, "available_seats": seats}
+    finally:
+        conn.close()
+
+
+@app.post("/bookings")
+def create_booking(event_id: int, seat_id: int, customer: str):
+    """booking role: reserve a seat for a customer."""
+    conn = db.connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO bookings (event_id, seat_id, customer) "
+                "VALUES (%s, %s, %s) RETURNING id",
+                (event_id, seat_id, customer),
+            )
+            booking_id = cur.fetchone()[0]
+            cur.execute("UPDATE seats SET status = 'booked' WHERE id = %s", (seat_id,))
+        conn.commit()
+        return {"booking_id": booking_id, "status": "reserved"}
+    finally:
+        conn.close()
+
+
+@app.post("/payments")
+def create_payment(booking_id: int, amount_cents: int):
+    """payment role: record a payment for a booking."""
+    conn = db.connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO payments (booking_id, amount_cents, status) "
+                "VALUES (%s, %s, 'captured') RETURNING id",
+                (booking_id, amount_cents),
+            )
+            payment_id = cur.fetchone()[0]
+        conn.commit()
+        return {"payment_id": payment_id, "status": "captured"}
+    finally:
+        conn.close()

--- a/ticketing-incident-demo/build.sh
+++ b/ticketing-incident-demo/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 docker buildx build --platform linux/amd64 --push . \
-  -t us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+  -t europe-docker.pkg.dev/robusta-development/kubernetes-demos/ticketing-service:v1

--- a/ticketing-incident-demo/build.sh
+++ b/ticketing-incident-demo/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+docker buildx build --platform linux/amd64 --push . \
+  -t us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1

--- a/ticketing-incident-demo/grafana-test-alert.md
+++ b/ticketing-incident-demo/grafana-test-alert.md
@@ -1,0 +1,90 @@
+# Stage #3 — Grafana "Test contact point" payload
+
+Use this to fire a realistic `KubePodCrashLooping` alert at the incident.io contact
+point **without** waiting for a real CrashLoopBackOff alert to fire. It mimics the
+alert that `kube-prometheus-stack` emits for the broken `seat-selection` pod as
+closely as possible.
+
+## Option A — Grafana UI (recommended)
+
+In Grafana: **Alerting → Contact points → (your incident.io contact point) → Test**.
+Choose **Custom** and fill in the annotations and labels below.
+
+### Labels
+
+| Key                | Value                                  |
+|--------------------|----------------------------------------|
+| `alertname`        | `KubePodCrashLooping`                  |
+| `severity`         | `low`                                  |
+| `namespace`        | `ticketing`                            |
+| `pod`              | `seat-selection-7d9c8c6b4f-x2k9p`      |
+| `container`        | `seat-selection`                       |
+| `reason`           | `CrashLoopBackOff`                     |
+| `job`              | `kube-state-metrics`                   |
+| `cluster`          | `prod-us-central1`                     |
+
+> Note: real `KubePodCrashLooping` defaults to `severity: warning`. The ticket
+> scenario intentionally starts at `severity: low` so that Holmes is the one to
+> recognize the real (Urgent) business impact and escalate.
+
+### Annotations
+
+| Key           | Value                                                                                               |
+|---------------|-----------------------------------------------------------------------------------------------------|
+| `summary`     | `Pod is crash looping.`                                                                              |
+| `description` | `Pod ticketing/seat-selection-7d9c8c6b4f-x2k9p (seat-selection) is in waiting state (reason: "CrashLoopBackOff").` |
+| `runbook_url` | `https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping`                  |
+
+## Option B — Raw webhook body (fallback)
+
+If you test the webhook directly instead of via Grafana's UI, this is the
+Grafana-style alert payload to POST:
+
+```json
+{
+  "receiver": "incident-io",
+  "status": "firing",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "KubePodCrashLooping",
+        "severity": "low",
+        "namespace": "ticketing",
+        "pod": "seat-selection-7d9c8c6b4f-x2k9p",
+        "container": "seat-selection",
+        "reason": "CrashLoopBackOff",
+        "job": "kube-state-metrics",
+        "cluster": "prod-us-central1"
+      },
+      "annotations": {
+        "summary": "Pod is crash looping.",
+        "description": "Pod ticketing/seat-selection-7d9c8c6b4f-x2k9p (seat-selection) is in waiting state (reason: \"CrashLoopBackOff\").",
+        "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"
+      },
+      "startsAt": "2026-06-22T09:00:00Z",
+      "generatorURL": "https://grafana.example.com/alerting/grafana/kubepodcrashlooping"
+    }
+  ],
+  "groupLabels": {
+    "alertname": "KubePodCrashLooping",
+    "namespace": "ticketing"
+  },
+  "commonLabels": {
+    "alertname": "KubePodCrashLooping",
+    "severity": "low",
+    "namespace": "ticketing",
+    "pod": "seat-selection-7d9c8c6b4f-x2k9p"
+  },
+  "commonAnnotations": {
+    "summary": "Pod is crash looping."
+  },
+  "externalURL": "https://grafana.example.com"
+}
+```
+
+## Expected result
+
+A new incident is created in incident.io in **Triage** status. The incident.io
+workflow adds the `holmes-staging` bot to the incident channel, which triggers
+Holmes to investigate the `seat-selection` pod in the `ticketing` namespace.

--- a/ticketing-incident-demo/manifest.yaml
+++ b/ticketing-incident-demo/manifest.yaml
@@ -204,7 +204,7 @@ spec:
     spec:
       containers:
       - name: booking
-        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+        image: europe-docker.pkg.dev/robusta-development/kubernetes-demos/ticketing-service:v1
         ports:
         - containerPort: 8000
         env:
@@ -299,7 +299,7 @@ spec:
     spec:
       containers:
       - name: payment
-        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+        image: europe-docker.pkg.dev/robusta-development/kubernetes-demos/ticketing-service:v1
         ports:
         - containerPort: 8000
         env:
@@ -397,7 +397,7 @@ spec:
     spec:
       containers:
       - name: seat-selection
-        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+        image: europe-docker.pkg.dev/robusta-development/kubernetes-demos/ticketing-service:v1
         ports:
         - containerPort: 8000
         env:

--- a/ticketing-incident-demo/manifest.yaml
+++ b/ticketing-incident-demo/manifest.yaml
@@ -1,0 +1,458 @@
+# Ticketing platform demo - deployed in a BROKEN state.
+#
+# The seat-selection service was updated and shipped with a wrong DB_HOST
+# (ticketing-db-prod, which does not resolve), so it crash-loops and customers
+# cannot pick seats or complete a purchase. The booking and payment services use
+# the correct DB_HOST (ticketing-db) and stay healthy.
+#
+# Deploy:  kubectl apply -f manifest.yaml
+# Cleanup: kubectl delete -f manifest.yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ticketing
+  labels:
+    app.kubernetes.io/part-of: ticketing-platform
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ticketing-db-credentials
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: ticketing-db
+    app.kubernetes.io/part-of: ticketing-platform
+    app.kubernetes.io/component: database
+type: Opaque
+stringData:
+  POSTGRES_USER: ticketing
+  POSTGRES_PASSWORD: ticketing-demo-password
+  POSTGRES_DB: ticketing
+---
+# Schema + seed data, loaded by the postgres entrypoint on first start.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ticketing-db-initdb
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: ticketing-db
+    app.kubernetes.io/part-of: ticketing-platform
+    app.kubernetes.io/component: database
+data:
+  01-schema.sql: |
+    CREATE TABLE events (
+        id          SERIAL PRIMARY KEY,
+        name        TEXT NOT NULL,
+        starts_at   TIMESTAMPTZ NOT NULL
+    );
+
+    CREATE TABLE seats (
+        id          SERIAL PRIMARY KEY,
+        event_id    INTEGER NOT NULL REFERENCES events(id),
+        row_label   TEXT NOT NULL,
+        seat_number INTEGER NOT NULL,
+        status      TEXT NOT NULL DEFAULT 'available'
+    );
+
+    CREATE TABLE bookings (
+        id          SERIAL PRIMARY KEY,
+        event_id    INTEGER NOT NULL REFERENCES events(id),
+        seat_id     INTEGER NOT NULL REFERENCES seats(id),
+        customer    TEXT NOT NULL,
+        created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE TABLE payments (
+        id           SERIAL PRIMARY KEY,
+        booking_id   INTEGER NOT NULL REFERENCES bookings(id),
+        amount_cents INTEGER NOT NULL,
+        status       TEXT NOT NULL,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    INSERT INTO events (name, starts_at) VALUES
+        ('Coldplay - Music of the Spheres', now() + interval '30 days'),
+        ('NBA Finals Game 7', now() + interval '7 days');
+
+    INSERT INTO seats (event_id, row_label, seat_number) VALUES
+        (1, 'A', 1), (1, 'A', 2), (1, 'A', 3),
+        (1, 'B', 1), (1, 'B', 2),
+        (2, 'A', 1), (2, 'A', 2);
+---
+# Shared, CORRECT database connection settings. seat-selection overrides DB_HOST
+# below with a bad value - that override is the bug.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ticketing-db-config
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/part-of: ticketing-platform
+data:
+  DB_HOST: ticketing-db
+  DB_PORT: "5432"
+  DB_NAME: ticketing
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ticketing-db
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: ticketing-db
+    app.kubernetes.io/instance: ticketing-db
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: ticketing-platform
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "16"
+    tier: data
+    business-criticality: tier-1
+    team: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ticketing-db
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ticketing-db
+        app.kubernetes.io/instance: ticketing-db
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: ticketing-platform
+        tier: data
+        business-criticality: tier-1
+        team: platform
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16-alpine
+        ports:
+        - containerPort: 5432
+        envFrom:
+        - secretRef:
+            name: ticketing-db-credentials
+        volumeMounts:
+        - name: initdb
+          mountPath: /docker-entrypoint-initdb.d
+        readinessProbe:
+          exec:
+            command: ["pg_isready", "-U", "ticketing", "-d", "ticketing"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 256Mi
+      volumes:
+      - name: initdb
+        configMap:
+          name: ticketing-db-initdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ticketing-db
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: ticketing-db
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: ticketing-platform
+spec:
+  selector:
+    app.kubernetes.io/name: ticketing-db
+  ports:
+  - protocol: TCP
+    port: 5432
+    targetPort: 5432
+---
+# booking service - healthy (uses the correct DB_HOST from ticketing-db-config)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: booking
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: booking
+    app.kubernetes.io/instance: booking
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ticketing-platform
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "2.3.1"
+    tier: backend
+    business-criticality: tier-1
+    team: checkout
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: booking
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: booking
+        app.kubernetes.io/instance: booking
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ticketing-platform
+        tier: backend
+        business-criticality: tier-1
+        team: checkout
+    spec:
+      containers:
+      - name: booking
+        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+        ports:
+        - containerPort: 8000
+        env:
+        - name: SERVICE_NAME
+          value: booking
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: ticketing-db-config
+              key: DB_HOST
+        - name: DB_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: ticketing-db-config
+              key: DB_PORT
+        - name: DB_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: ticketing-db-config
+              key: DB_NAME
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: ticketing-db-credentials
+              key: POSTGRES_USER
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ticketing-db-credentials
+              key: POSTGRES_PASSWORD
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: booking
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: booking
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ticketing-platform
+spec:
+  selector:
+    app.kubernetes.io/name: booking
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000
+---
+# payment service - healthy (uses the correct DB_HOST from ticketing-db-config)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: payment
+    app.kubernetes.io/instance: payment
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ticketing-platform
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "2.3.1"
+    tier: backend
+    business-criticality: tier-1
+    team: checkout
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment
+        app.kubernetes.io/instance: payment
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ticketing-platform
+        tier: backend
+        business-criticality: tier-1
+        team: checkout
+    spec:
+      containers:
+      - name: payment
+        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+        ports:
+        - containerPort: 8000
+        env:
+        - name: SERVICE_NAME
+          value: payment
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: ticketing-db-config
+              key: DB_HOST
+        - name: DB_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: ticketing-db-config
+              key: DB_PORT
+        - name: DB_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: ticketing-db-config
+              key: DB_NAME
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: ticketing-db-credentials
+              key: POSTGRES_USER
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ticketing-db-credentials
+              key: POSTGRES_PASSWORD
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: payment
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ticketing-platform
+spec:
+  selector:
+    app.kubernetes.io/name: payment
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000
+---
+# seat-selection service - BROKEN.
+# The last deploy set DB_HOST to "ticketing-db-prod", which does not resolve, so
+# the service cannot reach the database and crash-loops. The fix is a one-line
+# change: DB_HOST should be "ticketing-db" (as the booking/payment services use).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seat-selection
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: seat-selection
+    app.kubernetes.io/instance: seat-selection
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ticketing-platform
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "2.3.1"
+    tier: backend
+    business-criticality: tier-1
+    team: checkout
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: seat-selection
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: seat-selection
+        app.kubernetes.io/instance: seat-selection
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ticketing-platform
+        tier: backend
+        business-criticality: tier-1
+        team: checkout
+    spec:
+      containers:
+      - name: seat-selection
+        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/ticketing-service:v1
+        ports:
+        - containerPort: 8000
+        env:
+        - name: SERVICE_NAME
+          value: seat-selection
+        # BUG: wrong database host shipped in the last update.
+        # Should be "ticketing-db" (see ticketing-db-config / booking & payment).
+        - name: DB_HOST
+          value: ticketing-db-prod
+        - name: DB_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: ticketing-db-config
+              key: DB_PORT
+        - name: DB_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: ticketing-db-config
+              key: DB_NAME
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: ticketing-db-credentials
+              key: POSTGRES_USER
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ticketing-db-credentials
+              key: POSTGRES_PASSWORD
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seat-selection
+  namespace: ticketing
+  labels:
+    app.kubernetes.io/name: seat-selection
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ticketing-platform
+spec:
+  selector:
+    app.kubernetes.io/name: seat-selection
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/ticketing-incident-demo/requirements.txt
+++ b/ticketing-incident-demo/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+psycopg2-binary==2.9.9


### PR DESCRIPTION
## What

Adds `ticketing-incident-demo/` — a small ticketing-company microservices environment for the incident.io / HolmesGPT first-responder demo ([ROB-412](https://linear.app/robusta/issue/ROB-412/demo-with-incidentio-for-natan)), covering **"Building it → Setting up the environment" stages #2 and #3**.

### Scenario
Three services (`seat-selection`, `booking`, `payment`) share one PostgreSQL DB. The `seat-selection` service was shipped with a wrong `DB_HOST` env var and crash-loops (`KubePodCrashLooping`), so customers can't buy tickets — a low-severity alert that's actually an urgent, revenue-impacting incident.

### Stage #2 — the cluster app
- **Real FastAPI mini-app** (`app/`), one shared image run as 3 roles via `SERVICE_NAME`. On startup it retries Postgres and, if unreachable, logs a `FATAL` line and exits → genuine `CrashLoopBackOff` (not a fake script, so Holmes's RCA stays credible).
- **`manifest.yaml`**: namespace `ticketing`, seeded `postgres:16-alpine`, healthy `booking`/`payment`, and a broken `seat-selection` with inline `DB_HOST: ticketing-db-prod` (doesn't resolve). The fix is a one-line change → trivial Holmes PR.
- **Best-practice labels** (k8s recommended set + `business-criticality: tier-1`, `team`, version bump) so Holmes can *infer* business impact with no prior knowledge of the env.

### Stage #3 — the alert
- `grafana-test-alert.md`: copy-paste Labels/Summary/Description/Runbook URL for Grafana's **Test contact point**, mimicking a real `KubePodCrashLooping` for the seat-selection pod, plus a raw JSON webhook fallback.

Also adds an entry under **Advanced Scenarios** in the top-level README, and a reskin table for E-commerce / Banking flavors.

## Why Holmes can root-cause it unaided
1. Real Postgres error in the pod logs naming the bad host.
2. The bad env var is plainly visible in the Deployment spec.
3. Healthy `booking`/`payment` use the correct host — a built-in diff.
4. Criticality/ownership labels convey tier-1 impact.

## Notes before the demo
- **Image must be built/pushed once** via `./build.sh` (manifest references `ticketing-service:v1`). Not built here (no Docker/registry access) and not yet applied to a live cluster.
- **Namespace is `ticketing`** (the ticket said `payment`); if any incident.io filter keys on `namespace=payment`, update `grafana-test-alert.md` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JEvpXJyVPG18eEoV8xYYk

---
_Generated by [Claude Code](https://claude.ai/code/session_018JEvpXJyVPG18eEoV8xYYk)_