### PR TITLE
Add argocd-regression-demo (ArgoCD deploy → triggered-workflow regression detection)

### DIFF
--- a/argocd-regression-demo/README.md
+++ b/argocd-regression-demo/README.md
@@ -11,48 +11,90 @@ workload, reads the offending Git commit, and reports the root cause to Slack.
 
 ## Prerequisites
 
-Set these up before running the demo:
+- A Kubernetes cluster and `kubectl` access (plus `curl`, `sed`, `bash` locally).
+- **HolmesGPT** running with a **Triggered Workflow** webhook endpoint (a URL + auth token).
+- Holmes integrations: in-cluster **kubectl** access, **GitHub** read (to fetch the commit
+  diff for the synced revision), and **Slack** (Holmes posts findings to a channel you choose).
 
-1. A Kubernetes cluster and `kubectl` access.
-2. **ArgoCD** installed, including its bundled **notifications controller** (ships with ArgoCD).
-3. **HolmesGPT** running with a **Triggered Workflow** webhook endpoint (a URL + auth token
-   that starts an investigation from an inbound webhook).
-4. Holmes integrations:
-   - in-cluster **kubectl** access,
-   - **GitHub** read access (to fetch the commit diff for the synced revision),
-   - **Slack** (Holmes posts its findings to a channel you choose).
-5. A **dedicated Git branch** that ArgoCD will track (not `main`) — the regression commit is
-   made here on camera, then reverted. Create it from this repo, e.g. `argocd-regression-demo-live`.
+ArgoCD itself does **not** need to be pre-installed — the script below installs a dedicated,
+self-contained instance.
 
-## Setup
+## One-time setup
 
-1. Fill in the placeholders:
-   - `argocd/application.yaml` → `__REPO_URL__`, `__LIVE_BRANCH__`
-   - `argocd/notifications.yaml` → `__WEBHOOK_URL__`, `__WEBHOOK_TOKEN__`
-2. Configure the Triggered Workflow in Holmes with the prompt in
-   [`triggered-workflow-prompt.txt`](./triggered-workflow-prompt.txt).
-3. Apply the notifications config and the Application:
+1. **Install ArgoCD + deploy the app** (installs into its own `argocd-demo` namespace, so it
+   won't clash with any existing ArgoCD):
+
    ```bash
-   kubectl apply -f argocd/notifications.yaml
-   kubectl apply -f argocd/application.yaml
-   ```
-4. Confirm the baseline is healthy: in the ArgoCD UI the `storefront` app is **Synced /
-   Healthy**, and `kubectl get pods -n storefront` shows `frontend`, `api`, `worker` Running.
+   # minimal: ArgoCD + the demo Application, no Holmes wiring yet
+   ./install-argocd.sh
 
-## Run the demo
-
-1. On the tracked branch, edit `gitops/manifest.yaml` and change **one** service's image to a
-   non-existent tag, e.g.:
-   ```yaml
-   # frontend Deployment
-   image: nginx:1.99.9-nope   # was nginx:1.27.4
+   # or wire Holmes in at the same time:
+   WEBHOOK_URL="https://<holmes-triggered-workflow>" WEBHOOK_TOKEN="<token>" ./install-argocd.sh
    ```
-2. Commit and push to the tracked branch.
-3. ArgoCD auto-syncs the new revision → the new `frontend` pods get stuck in
-   `ImagePullBackOff` (old pods keep serving) → the `on-sync-succeeded` webhook fires.
-4. Holmes investigates and posts to Slack: the affected service, the `ImagePullBackOff`
-   symptom, the offending commit and exact line (the bad image tag), and a recommended revert.
-5. **Reset:** `git revert` the commit (or reset the branch); ArgoCD self-heals back to green.
+
+   Overridable via env vars: `NAMESPACE`, `ARGOCD_VERSION`, `REPO_URL`, `LIVE_BRANCH`,
+   `WEBHOOK_URL`, `WEBHOOK_TOKEN` (see the top of `install-argocd.sh`).
+
+2. **Create the branch ArgoCD tracks** (the live branch where the regression commit is made —
+   kept separate from `main`):
+
+   ```bash
+   git checkout -b argocd-regression-demo-live main
+   git push -u origin argocd-regression-demo-live
+   ```
+
+3. **Confirm the baseline is healthy:**
+
+   ```bash
+   kubectl get pods -n argocd-demo                       # all Running, incl. argocd-notifications-controller
+   kubectl get applications -n argocd-demo storefront    # Synced / Healthy
+   kubectl get pods -n storefront                        # frontend / api / worker Running
+   ```
+
+   ArgoCD UI (optional, for the recording):
+   ```bash
+   kubectl -n argocd-demo get secret argocd-initial-admin-secret -o jsonpath='{.data.password}'; echo
+   kubectl port-forward svc/argocd-server -n argocd-demo 8080:443   # then https://localhost:8080 (user: admin)
+   ```
+
+4. Configure the Triggered Workflow in Holmes with the prompt in
+   [`triggered-workflow-prompt.txt`](./triggered-workflow-prompt.txt).
+
+## Running the demo
+
+On the **live branch**, ship a bad deploy:
+
+```bash
+git checkout argocd-regression-demo-live
+# change ONE service's image to a non-existent tag, e.g. in gitops/manifest.yaml:
+#   image: nginx:1.99.9-nope      # was nginx:1.27.4
+git commit -am "deploy frontend nginx:1.99.9-nope"
+git push
+```
+
+Then watch it unfold:
+
+```bash
+kubectl get pods -n storefront -w     # new frontend pods -> ImagePullBackOff (old pods keep serving)
+kubectl get applications -n argocd-demo storefront   # turns Degraded within ~30s
+```
+
+ArgoCD's `on-sync-succeeded` webhook fires → Holmes investigates and posts to Slack: the
+affected service, the `ImagePullBackOff` symptom, the offending commit + exact line, and a
+recommended revert.
+
+## Re-running the demo
+
+Reset to green, then repeat:
+
+```bash
+git checkout argocd-regression-demo-live
+git reset --hard origin/main        # or: git revert HEAD
+git push --force-with-lease          # (force only needed if you used reset)
+```
+
+ArgoCD self-heals the app back to Healthy. Re-run by pushing the bad image tag again (vary the
+service or tag to keep each take distinct).
 
 ## How it works
 
@@ -67,7 +109,15 @@ git push (bad image tag) ─▶ ArgoCD auto-sync ─▶ on-sync-succeeded webhoo
 - **Why trigger on sync, not health?** `on-sync-succeeded` fires within seconds of the revision
   being applied. ArgoCD only marks the app `Degraded` after a Deployment's
   `progressDeadlineSeconds` of stalled rollout (default 600s). The manifests set it to `30s`
-  so the ArgoCD UI also turns red quickly for the recording — but that's just visual; the
-  webhook fires on the sync event.
+  so the UI also turns red quickly for the recording — but that's just visual; the webhook
+  fires on the sync event.
 - **Generic images.** The services run stock `nginx`; the broken image is never pulled, so
   nothing app-specific is needed. Swap in your own images/services to taste.
+
+## Files
+
+- `install-argocd.sh` — one-command installer (dedicated namespace, pinned ArgoCD, deploys the app).
+- `gitops/manifest.yaml` — desired-state services ArgoCD watches (the healthy baseline).
+- `argocd/application.yaml` — the ArgoCD Application (auto-sync).
+- `argocd/notifications.yaml` — webhook → Holmes wiring (trigger + payload template + secret).
+- `triggered-workflow-prompt.txt` — the Holmes regression-analysis prompt.

--- a/argocd-regression-demo/README.md
+++ b/argocd-regression-demo/README.md
@@ -96,6 +96,20 @@ git push --force-with-lease          # (force only needed if you used reset)
 ArgoCD self-heals the app back to Healthy. Re-run by pushing the bad image tag again (vary the
 service or tag to keep each take distinct).
 
+## Cleanup / uninstall
+
+Tear down the demo and the dedicated ArgoCD instance:
+
+```bash
+./install-argocd.sh --uninstall
+```
+
+This deletes the `storefront` and `argocd-demo` namespaces. It intentionally leaves
+ArgoCD's **cluster-scoped** resources (ClusterRoles/Bindings and the `*.argoproj.io` CRDs) in
+place, because those have fixed names shared with any other ArgoCD on the cluster — removing
+them could break a different ArgoCD install. If this was the only ArgoCD, the script prints the
+extra `kubectl delete` commands to remove them too.
+
 ## How it works
 
 ```

--- a/argocd-regression-demo/README.md
+++ b/argocd-regression-demo/README.md
@@ -1,0 +1,73 @@
+# ArgoCD deploy-regression demo (Triggered Workflow)
+
+Demonstrates **proactive, deploy-time regression detection**: an ArgoCD sync fires a webhook
+into a HolmesGPT **Triggered Workflow**, and Holmes analyzes the just-deployed service for a
+regression — no alert and no human in the loop. The deploy *itself* is the trigger.
+
+The scenario: a bad deploy points one service at a **non-existent image tag**. The rollout
+stalls on `ImagePullBackOff` while the old pods keep serving — a "quiet" regression that
+usually wouldn't page anyone. ArgoCD's sync event triggers Holmes, which inspects the changed
+workload, reads the offending Git commit, and reports the root cause to Slack.
+
+## Prerequisites
+
+Set these up before running the demo:
+
+1. A Kubernetes cluster and `kubectl` access.
+2. **ArgoCD** installed, including its bundled **notifications controller** (ships with ArgoCD).
+3. **HolmesGPT** running with a **Triggered Workflow** webhook endpoint (a URL + auth token
+   that starts an investigation from an inbound webhook).
+4. Holmes integrations:
+   - in-cluster **kubectl** access,
+   - **GitHub** read access (to fetch the commit diff for the synced revision),
+   - **Slack** (Holmes posts its findings to a channel you choose).
+5. A **dedicated Git branch** that ArgoCD will track (not `main`) — the regression commit is
+   made here on camera, then reverted. Create it from this repo, e.g. `argocd-regression-demo-live`.
+
+## Setup
+
+1. Fill in the placeholders:
+   - `argocd/application.yaml` → `__REPO_URL__`, `__LIVE_BRANCH__`
+   - `argocd/notifications.yaml` → `__WEBHOOK_URL__`, `__WEBHOOK_TOKEN__`
+2. Configure the Triggered Workflow in Holmes with the prompt in
+   [`triggered-workflow-prompt.txt`](./triggered-workflow-prompt.txt).
+3. Apply the notifications config and the Application:
+   ```bash
+   kubectl apply -f argocd/notifications.yaml
+   kubectl apply -f argocd/application.yaml
+   ```
+4. Confirm the baseline is healthy: in the ArgoCD UI the `storefront` app is **Synced /
+   Healthy**, and `kubectl get pods -n storefront` shows `frontend`, `api`, `worker` Running.
+
+## Run the demo
+
+1. On the tracked branch, edit `gitops/manifest.yaml` and change **one** service's image to a
+   non-existent tag, e.g.:
+   ```yaml
+   # frontend Deployment
+   image: nginx:1.99.9-nope   # was nginx:1.27.4
+   ```
+2. Commit and push to the tracked branch.
+3. ArgoCD auto-syncs the new revision → the new `frontend` pods get stuck in
+   `ImagePullBackOff` (old pods keep serving) → the `on-sync-succeeded` webhook fires.
+4. Holmes investigates and posts to Slack: the affected service, the `ImagePullBackOff`
+   symptom, the offending commit and exact line (the bad image tag), and a recommended revert.
+5. **Reset:** `git revert` the commit (or reset the branch); ArgoCD self-heals back to green.
+
+## How it works
+
+```
+git push (bad image tag) ─▶ ArgoCD auto-sync ─▶ on-sync-succeeded webhook
+   └▶ Holmes Triggered Workflow
+        ├─ kubectl rollout history / describe / events on the changed deploy
+        ├─ reads the synced commit diff from GitHub → the image-tag change
+        └▶ posts verdict + offending commit to Slack
+```
+
+- **Why trigger on sync, not health?** `on-sync-succeeded` fires within seconds of the revision
+  being applied. ArgoCD only marks the app `Degraded` after a Deployment's
+  `progressDeadlineSeconds` of stalled rollout (default 600s). The manifests set it to `30s`
+  so the ArgoCD UI also turns red quickly for the recording — but that's just visual; the
+  webhook fires on the sync event.
+- **Generic images.** The services run stock `nginx`; the broken image is never pulled, so
+  nothing app-specific is needed. Swap in your own images/services to taste.

--- a/argocd-regression-demo/README.md
+++ b/argocd-regression-demo/README.md
@@ -36,12 +36,17 @@ self-contained instance.
    `WEBHOOK_URL`, `WEBHOOK_TOKEN` (see the top of `install-argocd.sh`).
 
 2. **Create the branch ArgoCD tracks** (the live branch where the regression commit is made —
-   kept separate from `main`):
+   kept separate from `main`). Create it from a branch that already contains
+   `argocd-regression-demo/` — i.e. `main` once this folder is merged there:
 
    ```bash
    git checkout -b argocd-regression-demo-live main
    git push -u origin argocd-regression-demo-live
    ```
+
+   > Until `argocd-regression-demo/` is merged into `main`, branch from wherever the folder
+   > currently lives instead (e.g. `origin/<feature-branch>`), or ArgoCD will report
+   > "app path does not exist".
 
 3. **Confirm the baseline is healthy:**
 
@@ -85,15 +90,17 @@ recommended revert.
 
 ## Re-running the demo
 
-Reset to green, then repeat:
+Reset to green by **reverting** the regression commit — this keeps all the demo files on the
+branch (don't `git reset --hard origin/main`, which would wipe `argocd-regression-demo/` from
+the live branch unless `main` already contains it):
 
 ```bash
 git checkout argocd-regression-demo-live
-git reset --hard origin/main        # or: git revert HEAD
-git push --force-with-lease          # (force only needed if you used reset)
+git revert --no-edit HEAD     # undo the bad-image-tag commit, keep everything else
+git push
 ```
 
-ArgoCD self-heals the app back to Healthy. Re-run by pushing the bad image tag again (vary the
+ArgoCD self-heals the app back to Healthy. Re-run by pushing another bad image tag (vary the
 service or tag to keep each take distinct).
 
 ## Cleanup / uninstall

--- a/argocd-regression-demo/argocd/application.yaml
+++ b/argocd-regression-demo/argocd/application.yaml
@@ -8,7 +8,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: storefront
-  namespace: argocd
+  namespace: argocd-demo
   annotations:
     # Send a webhook to Holmes every time a new revision is successfully synced.
     notifications.argoproj.io/subscribe.on-sync-succeeded.holmes: ""

--- a/argocd-regression-demo/argocd/application.yaml
+++ b/argocd-regression-demo/argocd/application.yaml
@@ -1,0 +1,29 @@
+# ArgoCD Application that watches the gitops/ folder and auto-syncs it.
+#
+# Replace the placeholders before applying:
+#   __REPO_URL__        e.g. https://github.com/robusta-dev/kubernetes-demos
+#   __LIVE_BRANCH__     the dedicated branch ArgoCD tracks (NOT main), where the
+#                       regression commit is made on camera, e.g. argocd-regression-demo-live
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: storefront
+  namespace: argocd
+  annotations:
+    # Send a webhook to Holmes every time a new revision is successfully synced.
+    notifications.argoproj.io/subscribe.on-sync-succeeded.holmes: ""
+spec:
+  project: default
+  source:
+    repoURL: __REPO_URL__
+    path: argocd-regression-demo/gitops
+    targetRevision: __LIVE_BRANCH__
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: storefront
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/argocd-regression-demo/argocd/notifications.yaml
+++ b/argocd-regression-demo/argocd/notifications.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-notifications-cm
-  namespace: argocd
+  namespace: argocd-demo
 data:
   # The Holmes webhook as a notification "service".
   service.webhook.holmes: |
@@ -46,7 +46,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-notifications-secret
-  namespace: argocd
+  namespace: argocd-demo
 type: Opaque
 stringData:
   holmes-webhook-token: __WEBHOOK_TOKEN__

--- a/argocd-regression-demo/argocd/notifications.yaml
+++ b/argocd-regression-demo/argocd/notifications.yaml
@@ -1,0 +1,52 @@
+# Wires ArgoCD's notifications controller to call the Holmes Triggered Workflow
+# webhook whenever a revision is synced.
+#
+# Replace the placeholders before applying:
+#   __WEBHOOK_URL__     the Holmes Triggered Workflow endpoint
+#   __WEBHOOK_TOKEN__   the auth token for that endpoint
+#
+# Note: this patches the argocd-notifications-cm / -secret that ship with ArgoCD.
+# If you already use notifications, merge these keys instead of overwriting.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd
+data:
+  # The Holmes webhook as a notification "service".
+  service.webhook.holmes: |
+    url: __WEBHOOK_URL__
+    headers:
+    - name: Authorization
+      value: Bearer $holmes-webhook-token
+    - name: Content-Type
+      value: application/json
+
+  # Fire once per synced revision, regardless of resulting health (a bad image-tag
+  # deploy syncs successfully but never becomes Healthy).
+  trigger.on-sync-succeeded: |
+    - when: app.status.operationState.phase in ['Succeeded']
+      oncePer: app.status.sync.revision
+      send: [holmes-regression]
+
+  # Payload Holmes needs to fetch the commit diff and inspect the workload.
+  template.holmes-regression: |
+    webhook:
+      holmes:
+        method: POST
+        body: |
+          {
+            "app": "{{.app.metadata.name}}",
+            "revision": "{{.app.status.sync.revision}}",
+            "repoURL": "{{.app.spec.source.repoURL}}",
+            "namespace": "{{.app.spec.destination.namespace}}"
+          }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-notifications-secret
+  namespace: argocd
+type: Opaque
+stringData:
+  holmes-webhook-token: __WEBHOOK_TOKEN__

--- a/argocd-regression-demo/gitops/manifest.yaml
+++ b/argocd-regression-demo/gitops/manifest.yaml
@@ -1,0 +1,169 @@
+# Desired-state manifests that ArgoCD watches and syncs.
+#
+# Healthy baseline: three small nginx services. The demo introduces a "regression"
+# by changing ONE service's image tag to a non-existent one (e.g. nginx:1.99.9-nope)
+# and pushing it to the tracked branch. ArgoCD auto-syncs, the new pods get stuck in
+# ImagePullBackOff while the old ReplicaSet keeps serving, and the sync event triggers
+# a Holmes investigation.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: storefront
+  labels:
+    app.kubernetes.io/part-of: storefront
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: storefront
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: storefront
+    app.kubernetes.io/managed-by: argocd
+spec:
+  replicas: 2
+  # Lowered from the 600s default so ArgoCD shows the app Degraded within ~30s of a
+  # stalled rollout (visual effect only; the demo triggers on sync, not on health).
+  progressDeadlineSeconds: 30
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: storefront
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.27.4
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: storefront
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: storefront
+spec:
+  selector:
+    app.kubernetes.io/name: frontend
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: storefront
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: storefront
+    app.kubernetes.io/managed-by: argocd
+spec:
+  replicas: 2
+  progressDeadlineSeconds: 30
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: storefront
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.27.4
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: storefront
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/part-of: storefront
+spec:
+  selector:
+    app.kubernetes.io/name: api
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: storefront
+  labels:
+    app.kubernetes.io/name: worker
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: storefront
+    app.kubernetes.io/managed-by: argocd
+spec:
+  replicas: 2
+  progressDeadlineSeconds: 30
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: worker
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/part-of: storefront
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.27.4
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: worker
+  namespace: storefront
+  labels:
+    app.kubernetes.io/name: worker
+    app.kubernetes.io/part-of: storefront
+spec:
+  selector:
+    app.kubernetes.io/name: worker
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80

--- a/argocd-regression-demo/install-argocd.sh
+++ b/argocd-regression-demo/install-argocd.sh
@@ -31,6 +31,31 @@ WEBHOOK_TOKEN="${WEBHOOK_TOKEN:-}"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_URL="https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml"
 
+# --- uninstall ---------------------------------------------------------------
+# Removes the demo and the dedicated ArgoCD namespace. Leaves ArgoCD's
+# cluster-scoped resources (ClusterRoles/Bindings, CRDs) in place because they
+# share fixed names with any other ArgoCD on the cluster; removing them could
+# break a different ArgoCD install. Optional commands to remove them are printed.
+if [[ "${1:-}" == "--uninstall" || "${1:-}" == "uninstall" ]]; then
+  echo "==> Uninstalling demo + ArgoCD namespace '${NAMESPACE}'"
+  kubectl delete application storefront -n "${NAMESPACE}" --ignore-not-found
+  kubectl delete namespace storefront --ignore-not-found
+  kubectl delete namespace "${NAMESPACE}" --ignore-not-found
+  cat <<EOF
+
+==> Done. The dedicated namespaces are gone.
+
+ArgoCD's cluster-scoped resources were left in place (they may be shared with
+another ArgoCD on this cluster). If this was the ONLY ArgoCD, remove them with:
+
+  kubectl delete clusterrole argocd-application-controller argocd-server argocd-applicationset-controller --ignore-not-found
+  kubectl delete clusterrolebinding argocd-application-controller argocd-server argocd-applicationset-controller --ignore-not-found
+  kubectl delete crd applications.argoproj.io appprojects.argoproj.io applicationsets.argoproj.io --ignore-not-found
+EOF
+  exit 0
+fi
+# -----------------------------------------------------------------------------
+
 echo "==> Installing ArgoCD ${ARGOCD_VERSION} into namespace '${NAMESPACE}'"
 
 # 1. namespace (idempotent)
@@ -39,10 +64,12 @@ kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply
 # 2. ArgoCD core (incl. notifications controller). The upstream manifest hardcodes
 #    'namespace: argocd' in its ClusterRoleBinding/RoleBinding subjects, so rewrite
 #    it to our namespace before applying.
+#    Use server-side apply: ArgoCD's ApplicationSet CRD exceeds the 262144-byte
+#    annotation limit that client-side `kubectl apply` would hit.
 echo "==> Applying ArgoCD manifests"
 curl -sSL "${INSTALL_URL}" \
   | sed "s|namespace: argocd$|namespace: ${NAMESPACE}|g" \
-  | kubectl apply -n "${NAMESPACE}" -f -
+  | kubectl apply --server-side --force-conflicts -n "${NAMESPACE}" -f -
 
 # 3. wait for the CRDs and the controllers to be ready
 echo "==> Waiting for ArgoCD to become ready"

--- a/argocd-regression-demo/install-argocd.sh
+++ b/argocd-regression-demo/install-argocd.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# One-command install of a self-contained ArgoCD for this demo.
+#
+# Installs ArgoCD into its OWN namespace (default: argocd-demo) so it never
+# clashes with an existing ArgoCD in the cluster, then deploys the demo
+# Application (and, if a webhook is provided, the Holmes notification wiring).
+#
+# Usage:
+#   ./install-argocd.sh
+#
+# Override any of these via environment variables:
+#   NAMESPACE        namespace to install ArgoCD into        (default: argocd-demo)
+#   ARGOCD_VERSION   pinned ArgoCD release to install        (default: v3.4.4)
+#   REPO_URL         git repo ArgoCD syncs from              (default: this public repo)
+#   LIVE_BRANCH      branch ArgoCD tracks (NOT main)         (default: argocd-regression-demo-live)
+#   WEBHOOK_URL      Holmes Triggered Workflow endpoint      (optional)
+#   WEBHOOK_TOKEN    auth token for that endpoint            (optional)
+#
+# If WEBHOOK_URL and WEBHOOK_TOKEN are both set, the notification wiring is
+# applied; otherwise it is skipped (you can apply it later).
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-argocd-demo}"
+ARGOCD_VERSION="${ARGOCD_VERSION:-v3.4.4}"
+REPO_URL="${REPO_URL:-https://github.com/robusta-dev/kubernetes-demos}"
+LIVE_BRANCH="${LIVE_BRANCH:-argocd-regression-demo-live}"
+WEBHOOK_URL="${WEBHOOK_URL:-}"
+WEBHOOK_TOKEN="${WEBHOOK_TOKEN:-}"
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_URL="https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml"
+
+echo "==> Installing ArgoCD ${ARGOCD_VERSION} into namespace '${NAMESPACE}'"
+
+# 1. namespace (idempotent)
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+# 2. ArgoCD core (incl. notifications controller). The upstream manifest hardcodes
+#    'namespace: argocd' in its ClusterRoleBinding/RoleBinding subjects, so rewrite
+#    it to our namespace before applying.
+echo "==> Applying ArgoCD manifests"
+curl -sSL "${INSTALL_URL}" \
+  | sed "s|namespace: argocd$|namespace: ${NAMESPACE}|g" \
+  | kubectl apply -n "${NAMESPACE}" -f -
+
+# 3. wait for the CRDs and the controllers to be ready
+echo "==> Waiting for ArgoCD to become ready"
+kubectl wait --for=condition=established --timeout=60s crd/applications.argoproj.io
+for d in argocd-server argocd-repo-server argocd-notifications-controller; do
+  kubectl rollout status "deploy/${d}" -n "${NAMESPACE}" --timeout=300s
+done
+kubectl rollout status statefulset/argocd-application-controller -n "${NAMESPACE}" --timeout=300s
+
+# 4. deploy the demo Application (substitute placeholders + namespace)
+echo "==> Deploying demo Application (repo=${REPO_URL}, branch=${LIVE_BRANCH})"
+sed -e "s|__REPO_URL__|${REPO_URL}|g" \
+    -e "s|__LIVE_BRANCH__|${LIVE_BRANCH}|g" \
+    -e "s|namespace: argocd-demo|namespace: ${NAMESPACE}|g" \
+    "${DIR}/argocd/application.yaml" | kubectl apply -f -
+
+# 5. notification wiring (only if a webhook was provided)
+if [[ -n "${WEBHOOK_URL}" && -n "${WEBHOOK_TOKEN}" ]]; then
+  echo "==> Applying Holmes notification wiring"
+  sed -e "s|__WEBHOOK_URL__|${WEBHOOK_URL}|g" \
+      -e "s|__WEBHOOK_TOKEN__|${WEBHOOK_TOKEN}|g" \
+      -e "s|namespace: argocd-demo|namespace: ${NAMESPACE}|g" \
+      "${DIR}/argocd/notifications.yaml" | kubectl apply -f -
+else
+  echo "==> Skipping notification wiring (set WEBHOOK_URL and WEBHOOK_TOKEN to enable)"
+fi
+
+# 6. confirmation
+cat <<EOF
+
+==> Done. Confirm with:
+
+  kubectl get pods -n ${NAMESPACE}
+  kubectl get applications -n ${NAMESPACE} storefront
+  kubectl get pods -n storefront
+
+Open the ArgoCD UI (optional):
+
+  admin password:
+    kubectl -n ${NAMESPACE} get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d; echo
+  port-forward:
+    kubectl port-forward svc/argocd-server -n ${NAMESPACE} 8080:443
+  then browse https://localhost:8080  (user: admin)
+EOF

--- a/argocd-regression-demo/triggered-workflow-prompt.txt
+++ b/argocd-regression-demo/triggered-workflow-prompt.txt
@@ -84,29 +84,29 @@ _Triggered by ArgoCD sync of `<app>` @ `<short-revision>`_
 - Sections are exactly TL;DR → Evidence → Next Steps, then the closing question. No Root Cause / Fix / Impact / Conclusion sections.
 - Concise and direct. No padding, no drama.
 
-## Example — bad deploy · stalled rollout · Medium
+## Example — bad deploy · crash loop on missing config · High
+(Illustrative — a different scenario from the demo, to show the format.)
 ````
 🔍 *Automated RCA from HolmesGPT*
-_Triggered by ArgoCD sync of `storefront` @ `a1b2c3d`_
+_Triggered by ArgoCD sync of `payments` @ `7f3c901`_
 <https://platform.robusta.dev/holmes/triggered-workflows|View full investigation>
 
-*Triaged: Medium* 🔼
+*Triaged: High* ⏫
 
-*TL;DR:* The latest `storefront` deploy points `frontend` at an image tag that doesn't exist, so its new pods are stuck in `ImagePullBackOff` — the previous version is still serving, so there's no customer impact yet.
+*TL;DR:* The latest `payments` deploy rolled `payment-gateway` to `:1.8.0`, which crash-loops on startup because it needs a config key the manifest never set — the rollout is stalled and the old version is still serving, but it's one bad restart away from a payments outage.
 
 *Evidence*
-• Failed rollout — `frontend` new ReplicaSet is `0/2` ready, pods in `ImagePullBackOff`; `api` and `worker` are healthy
-• Still serving — the previous `frontend` ReplicaSet is up, so live traffic is unaffected for now
-• Offending commit — `a1b2c3d` changed `frontend` image `nginx:1.27.4` → `nginx:1.99.9-nope` (<https://github.com/robusta-dev/kubernetes-demos/commit/a1b2c3d|view diff>)
-• Kubelet event — from a failing `frontend` pod:
+• Crash loop — `payment-gateway` new pods are `CrashLoopBackOff`, `0/3` ready, restarting every ~20s
+• Still serving — the previous `payment-gateway` ReplicaSet is up, so payments are flowing for now
+• Offending commit — `7f3c901` bumped `payment-gateway` image `:1.7.4` → `:1.8.0` (<https://github.com/your-org/payments/commit/7f3c901|view diff>)
+• Startup failure — log from a crashing pod:
 ```
-Failed to pull image "nginx:1.99.9-nope": not found
-Back-off pulling image "nginx:1.99.9-nope"
+FATAL: missing required config STRIPE_WEBHOOK_SECRET
 ```
 
 *Next Steps*
-1. Revert `frontend` to the last good tag `nginx:1.27.4`
+1. Roll `payment-gateway` back to `:1.7.4` (or add the `STRIPE_WEBHOOK_SECRET` the new version requires)
 2. Confirm the new pods reach Ready
 
-<https://github.com/robusta-dev/kubernetes-demos/pull/319|PR #319> (revert to `nginx:1.27.4`) is ready for your review — want me to change anything before you merge?
+<https://github.com/your-org/payments/pull/204|PR #204> (roll back to `:1.7.4`) is ready for your review — want me to change anything before you merge?
 ````

--- a/argocd-regression-demo/triggered-workflow-prompt.txt
+++ b/argocd-regression-demo/triggered-workflow-prompt.txt
@@ -1,21 +1,112 @@
-You are an SRE assistant investigating a Kubernetes deployment that was just rolled out by ArgoCD. Your job is to determine whether this deploy introduced a regression, and if so, report it.
+You have received a JSON payload from an ArgoCD sync notification, and you are connected to a Kubernetes cluster (kubectl) and to GitHub (read). A new revision was just deployed by ArgoCD. Your job is to determine whether this deploy introduced a regression, and post one summary to Slack.
 
-You received this context from the ArgoCD sync event:
-- Application: {{app}}
-- Synced Git revision (commit SHA): {{revision}}
-- Git repository: {{repoURL}}
-- Namespace: {{namespace}}
+The payload contains:
+- app        — the ArgoCD Application name (e.g. "storefront")
+- revision   — the synced Git commit SHA
+- repoURL    — the Git repository the app is synced from
+- namespace  — the namespace the app deploys into
 
-Investigate:
-1. List the workloads in the namespace and their rollout status. For each Deployment, check `kubectl rollout history`, `kubectl describe`, recent `kubectl get events`, and pod status. Identify any deployment whose newest ReplicaSet is failing to roll out (e.g. ImagePullBackOff/ErrImagePull, CrashLoopBackOff, failing readiness, stuck Progressing).
-2. For the affected deployment, determine exactly what changed in this deploy. Fetch the diff for commit {{revision}} from the Git repository ({{repoURL}}) and find the change responsible — for an image-pull failure, the changed image tag.
-3. Confirm scope: which service is affected, and are the other services in the namespace still healthy (old pods still serving)?
+Your goals:
+1. Inspect the workloads in `namespace`. Find any deployment whose newest ReplicaSet is failing to roll out — ImagePullBackOff/ErrImagePull, CrashLoopBackOff, failing readiness, or a rollout stuck in Progressing. Use `kubectl rollout history`, `kubectl describe`, `kubectl get events`, and `kubectl get pods`.
+2. Determine exactly what changed in this deploy. Fetch the diff for commit `revision` from `repoURL` on GitHub and find the change responsible (for an image-pull failure, the changed image tag).
+3. Decide whether this is a real regression. Set a priority based on blast radius — is the whole app down, or is the previous version still serving (e.g. a stalled rollout where old pods keep handling traffic)?
+4. Post ONE message to the `#argocd-deploys` Slack channel, using the format in "HolmesGPT — Slack Message Prompt" below.
+5. Remediation: if you can open a pull request, open one that reverts/rolls back the offending change and reference it in the closing question. If you cannot open a PR, do NOT say so — instead close by offering to open one. Only if the user later asks you to open it should you then explain you don't have permission. Never imply you can merge, apply, or roll out a change yourself.
 
-If you find a regression, post a concise message to Slack with:
-- The affected service and namespace.
-- The symptom (e.g. "new pods stuck in ImagePullBackOff; rollout stalled; previous version still serving").
-- The root cause: the offending commit ({{revision}}) and the exact changed line (e.g. the bad image tag).
-- A recommended action (e.g. revert the commit / roll back to the previous image tag).
-- A one-line impact note (e.g. "no customer impact yet — caught before it would page").
+Important:
+1. Only investigate the app/namespace from the payload. Do not wander to other apps or namespaces.
+2. If the deploy is healthy and not a regression, say so briefly (Triage), still post the message, and take no remediation.
 
-Be factual and concise. If you determine the deploy is healthy and not a regression, say so briefly and take no further action.
+--
+# HolmesGPT — Slack Message Prompt
+
+## Role
+After investigating a deploy, you post one summary message to the `#argocd-deploys` Slack channel. Output **Slack mrkdwn only**: `*bold*`, `_italic_`, `` `inline code` ``, code blocks, and `<url|text>` links. No preamble, no closing remarks, nothing outside the message.
+
+## Template
+````
+🔍 *Automated <RCA|Triage> from HolmesGPT*
+_Triggered by ArgoCD sync of `<app>` @ `<short-revision>`_
+<https://platform.robusta.dev/holmes/triggered-workflows|View full investigation>
+
+*Triaged: <Urgent|High|Medium|Low>* <icon>
+
+*TL;DR:* <one-sentence verdict — is this deploy a regression, and the bottom line on impact>
+
+*Evidence*
+• <Label> — <finding; wrap every identifier in `inline code`>
+• Offending commit — `<short-revision>` <what it changed> (<link to the commit/diff>)
+• <Label> — <what this snippet is and where it came from>:
+```
+<log / event / config snippet — keep this LAST in the section>
+```
+
+*Next Steps*
+1. <action>
+2. <action>
+
+<Closing question — ALWAYS end with one. See rules.>
+````
+
+## Rules
+
+**Title & header**
+- The title icon is always 🔍.
+- Title verb is *RCA* when you have identified the offending change, *Triage* when you are only assessing or calling the deploy clean/noise.
+- The trigger line anchors on the deploy: the `<app>` and the short commit SHA (first 7 chars of `revision`). There is no incident ID.
+- `View full investigation` links to the full Holmes investigation for this run. If you can resolve the run-specific URL, use it; if you cannot, still include the link but point it at `https://platform.robusta.dev/holmes/triggered-workflows`.
+- Always use `*Triaged: <priority>*` — never "Status" or "Severity".
+- Priority scale and fixed icons: Urgent ‼️ · High ⏫ · Medium 🔼 · Low 🔽.
+
+**Inline code**
+- Wrap every identifier in `inline code`: deployment / service / pod / namespace names, image tags, env vars, hostnames, commit SHAs, metric values, and thresholds (e.g. `frontend`, `storefront`, `nginx:1.27.4`, `a1b2c3d`, `0/2`). This is what makes the message scannable — do not leave identifiers as plain text.
+
+**TL;DR**
+- One sentence. It is a *verdict* (e.g. "bad image tag; old pods still serving, no customer impact yet"), not a restatement of the event.
+
+**Evidence**
+- Lead each bullet with a short label, then the finding.
+- Include the offending commit bullet with a link to the commit/diff on GitHub.
+- Note the scope: which service regressed, and whether siblings / the previous version are still healthy.
+- Before any snippet, say what it is and where it came from. Put the snippet *last* in the section; never add a bullet or prose after a code block within Evidence.
+- Never begin a line with inline code. Trim snippets to the lines that matter.
+
+**Next Steps**
+- Numbered, short, action-first (e.g. revert to the last good tag, confirm Ready).
+
+**Closing question (required)**
+- Every message ends with a question on its own line after Next Steps — part of the format, not optional. Never end on a statement.
+- If you opened a revert PR: point the reviewer to it and ask whether to revise it before they merge — e.g. "`PR #318` (revert to `:v2.3.0`) is ready for your review — want me to change anything before you merge?"
+- If you did not open a PR: close by offering to — e.g. "Want me to open a PR reverting `frontend` to `nginx:1.27.4`?" Do not pre-emptively mention any permission limitation; only if asked to proceed and you cannot, explain then.
+- Do not imply Holmes can approve, merge, apply, or roll out a change.
+
+**Structure & tone**
+- Sections are exactly TL;DR → Evidence → Next Steps, then the closing question. No Root Cause / Fix / Impact / Conclusion sections.
+- Concise and direct. No padding, no drama.
+
+## Example — bad deploy · stalled rollout · Medium
+````
+🔍 *Automated RCA from HolmesGPT*
+_Triggered by ArgoCD sync of `storefront` @ `a1b2c3d`_
+<https://platform.robusta.dev/holmes/triggered-workflows|View full investigation>
+
+*Triaged: Medium* 🔼
+
+*TL;DR:* The latest `storefront` deploy points `frontend` at an image tag that doesn't exist, so its new pods are stuck in `ImagePullBackOff` — the previous version is still serving, so there's no customer impact yet.
+
+*Evidence*
+• Failed rollout — `frontend` new ReplicaSet is `0/2` ready, pods in `ImagePullBackOff`; `api` and `worker` are healthy
+• Still serving — the previous `frontend` ReplicaSet is up, so live traffic is unaffected for now
+• Offending commit — `a1b2c3d` changed `frontend` image `nginx:1.27.4` → `nginx:1.99.9-nope` (<https://github.com/robusta-dev/kubernetes-demos/commit/a1b2c3d|view diff>)
+• Kubelet event — from a failing `frontend` pod:
+```
+Failed to pull image "nginx:1.99.9-nope": not found
+Back-off pulling image "nginx:1.99.9-nope"
+```
+
+*Next Steps*
+1. Revert `frontend` to the last good tag `nginx:1.27.4`
+2. Confirm the new pods reach Ready
+
+<https://github.com/robusta-dev/kubernetes-demos/pull/319|PR #319> (revert to `nginx:1.27.4`) is ready for your review — want me to change anything before you merge?
+````

--- a/argocd-regression-demo/triggered-workflow-prompt.txt
+++ b/argocd-regression-demo/triggered-workflow-prompt.txt
@@ -10,12 +10,14 @@ Your goals:
 1. Inspect the workloads in `namespace`. Find any deployment whose newest ReplicaSet is failing to roll out — ImagePullBackOff/ErrImagePull, CrashLoopBackOff, failing readiness, or a rollout stuck in Progressing. Use `kubectl rollout history`, `kubectl describe`, `kubectl get events`, and `kubectl get pods`.
 2. Determine exactly what changed in this deploy. Fetch the diff for commit `revision` from `repoURL` on GitHub and find the change responsible (for an image-pull failure, the changed image tag).
 3. Decide whether this is a real regression. Set a priority based on blast radius — is the whole app down, or is the previous version still serving (e.g. a stalled rollout where old pods keep handling traffic)?
-4. Post ONE message to the `#argocd-deploys` Slack channel, using the format in "HolmesGPT — Slack Message Prompt" below.
-5. Remediation: if you can open a pull request, open one that reverts/rolls back the offending change and reference it in the closing question. If you cannot open a PR, do NOT say so — instead close by offering to open one. Only if the user later asks you to open it should you then explain you don't have permission. Never imply you can merge, apply, or roll out a change yourself.
+4. Post ONE message to the `#argocd-deploys` Slack channel:
+   - Regression found → use the full format in "HolmesGPT — Slack Message Prompt" below.
+   - Clean deploy (no regression) → post the single-line "Clean sync" message below. Do NOT use the full template, the Evidence/Next Steps sections, or a closing question.
+5. Remediation (regression only): if you can open a pull request, open one that reverts/rolls back the offending change and reference it in the closing question. If you cannot open a PR, do NOT say so — instead close by offering to open one. Only if the user later asks you to open it should you then explain you don't have permission. Never imply you can merge, apply, or roll out a change yourself.
 
 Important:
 1. Only investigate the app/namespace from the payload. Do not wander to other apps or namespaces.
-2. If the deploy is healthy and not a regression, say so briefly (Triage), still post the message, and take no remediation.
+2. If the deploy is healthy and not a regression, post the one-line "Clean sync" message (below) and take no remediation — do not use the full template.
 
 --
 # HolmesGPT — Slack Message Prompt
@@ -23,7 +25,21 @@ Important:
 ## Role
 After investigating a deploy, you post one summary message to the `#argocd-deploys` Slack channel. Output **Slack mrkdwn only**: `*bold*`, `_italic_`, `` `inline code` ``, code blocks, and `<url|text>` links. No preamble, no closing remarks, nothing outside the message.
 
-## Template
+## Two modes
+- **Clean deploy (no regression):** post only the single line in "Clean sync" below — no Evidence, no Next Steps, no closing question.
+- **Regression found:** use the full "Template" below.
+
+## Clean sync (no regression)
+One line, nothing else:
+````
+🔍 *HolmesGPT — `<app>` @ `<short-revision>`:* clean deploy, no regression (<short reason — e.g. commit only touched non-workload files, or all workloads healthy on the same image>).
+````
+Example:
+````
+🔍 *HolmesGPT — `storefront` @ `02c211b`:* clean deploy, no regression (commit only touched non-workload files).
+````
+
+## Template (regression found)
 ````
 🔍 *Automated <RCA|Triage> from HolmesGPT*
 _Triggered by ArgoCD sync of `<app>` @ `<short-revision>`_
@@ -74,8 +90,8 @@ _Triggered by ArgoCD sync of `<app>` @ `<short-revision>`_
 **Next Steps**
 - Numbered, short, action-first (e.g. revert to the last good tag, confirm Ready).
 
-**Closing question (required)**
-- Every message ends with a question on its own line after Next Steps — part of the format, not optional. Never end on a statement.
+**Closing question (required for regression messages)**
+- Every regression message ends with a question on its own line after Next Steps — part of the format, not optional. Never end on a statement. (The clean-sync one-liner has no closing question.)
 - If you opened a revert PR: point the reviewer to it and ask whether to revise it before they merge — e.g. "`PR #318` (revert to `:v2.3.0`) is ready for your review — want me to change anything before you merge?"
 - If you did not open a PR: close by offering to — e.g. "Want me to open a PR reverting `frontend` to `nginx:1.27.4`?" Do not pre-emptively mention any permission limitation; only if asked to proceed and you cannot, explain then.
 - Do not imply Holmes can approve, merge, apply, or roll out a change.

--- a/argocd-regression-demo/triggered-workflow-prompt.txt
+++ b/argocd-regression-demo/triggered-workflow-prompt.txt
@@ -1,0 +1,21 @@
+You are an SRE assistant investigating a Kubernetes deployment that was just rolled out by ArgoCD. Your job is to determine whether this deploy introduced a regression, and if so, report it.
+
+You received this context from the ArgoCD sync event:
+- Application: {{app}}
+- Synced Git revision (commit SHA): {{revision}}
+- Git repository: {{repoURL}}
+- Namespace: {{namespace}}
+
+Investigate:
+1. List the workloads in the namespace and their rollout status. For each Deployment, check `kubectl rollout history`, `kubectl describe`, recent `kubectl get events`, and pod status. Identify any deployment whose newest ReplicaSet is failing to roll out (e.g. ImagePullBackOff/ErrImagePull, CrashLoopBackOff, failing readiness, stuck Progressing).
+2. For the affected deployment, determine exactly what changed in this deploy. Fetch the diff for commit {{revision}} from the Git repository ({{repoURL}}) and find the change responsible — for an image-pull failure, the changed image tag.
+3. Confirm scope: which service is affected, and are the other services in the namespace still healthy (old pods still serving)?
+
+If you find a regression, post a concise message to Slack with:
+- The affected service and namespace.
+- The symptom (e.g. "new pods stuck in ImagePullBackOff; rollout stalled; previous version still serving").
+- The root cause: the offending commit ({{revision}}) and the exact changed line (e.g. the bad image tag).
+- A recommended action (e.g. revert the commit / roll back to the previous image tag).
+- A one-line impact note (e.g. "no customer impact yet — caught before it would page").
+
+Be factual and concise. If you determine the deploy is healthy and not a regression, say so briefly and take no further action.

--- a/argocd-regression-demo/triggered-workflow-prompt.txt
+++ b/argocd-regression-demo/triggered-workflow-prompt.txt
@@ -34,9 +34,9 @@ One line, nothing else:
 ````
 🔍 *HolmesGPT — `<app>` @ `<short-revision>`:* clean deploy, no regression (<short reason — e.g. commit only touched non-workload files, or all workloads healthy on the same image>).
 ````
-Example:
+Example (illustrative — a different app from the demo):
 ````
-🔍 *HolmesGPT — `storefront` @ `02c211b`:* clean deploy, no regression (commit only touched non-workload files).
+🔍 *HolmesGPT — `payments` @ `5e1a9c2`:* clean deploy, no regression (commit only bumped a CI config, no workload manifests changed).
 ````
 
 ## Template (regression found)


### PR DESCRIPTION
Adds a self-contained demo of **proactive, deploy-time regression detection**. An ArgoCD sync fires a webhook into a HolmesGPT Triggered Workflow, which inspects the just-deployed workload, reads the offending Git commit, and reports the root cause to Slack — no alert and no human in the loop. The deploy itself is the trigger.

### Contents (`argocd-regression-demo/`)
- `gitops/manifest.yaml` — 3 stock-nginx services (healthy baseline), `progressDeadlineSeconds: 30` for a fast Degraded visual.
- `argocd/application.yaml` — auto-sync Application subscribed to `on-sync-succeeded`.
- `argocd/notifications.yaml` — argocd-notifications webhook service + trigger + payload template + secret.
- `triggered-workflow-prompt.txt` — generic Holmes regression-analysis prompt.
- `README.md` — prerequisites-first, then setup / run / how-it-works.

### Scenario
The regression is a **non-existent image tag** → `ImagePullBackOff`. The rollout stalls while the old pods keep serving, so it's a "quiet" deploy regression that usually wouldn't page anyone. ArgoCD's sync event triggers Holmes, which pinpoints the affected service, reads the offending commit/line, and recommends a revert.

### Notes
- Triggers on `on-sync-succeeded` (fires within seconds of apply; the bad-image deploy syncs successfully but never becomes Healthy).
- Placeholders (`__REPO_URL__`, `__LIVE_BRANCH__`, `__WEBHOOK_URL__`, `__WEBHOOK_TOKEN__`) are documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JEvpXJyVPG18eEoV8xYYk

---
_Generated by [Claude Code](https://claude.ai/code/session_018JEvpXJyVPG18eEoV8xYYk)_