### PR TITLE
Add argocd-log-analysis-demo (ArgoCD + Loki: logs reveal a silent regression)

### DIFF
--- a/argocd-log-analysis-demo/README.md
+++ b/argocd-log-analysis-demo/README.md
@@ -1,0 +1,117 @@
+# ArgoCD + Loki log-analysis demo
+
+Demonstrates HolmesGPT catching a problem that **health checks can't see**: a new version
+deploys, the pods are Running and `/healthz` is green — but the **logs** show the new build is
+silently failing. An ArgoCD sync fires a webhook into a HolmesGPT **Triggered Workflow**, which
+compares **Loki logs before vs after** the deploy and classifies what changed.
+
+Why Loki: after a deploy the old pods are gone, so only centralized logs retain the *pre-deploy*
+baseline — that's what lets Holmes say "this error is new" vs "that was already there".
+
+The app (`checkout-api`) ships as two real image tags. `:v1` is the healthy baseline; `:v2`
+keeps returning `200` but its pricing path throws on some orders (totals silently break), plus a
+harmless new deprecation warning. The "deploy" is an honest **image-tag bump** in git — nothing
+at runtime marks it as a demo.
+
+## Prerequisites
+
+- A Kubernetes cluster + `kubectl` (and `curl`/`sed`/`bash`).
+- **HolmesGPT** with a **Triggered Workflow** webhook endpoint (URL + token).
+- Holmes integrations:
+  - the **`grafana/loki` toolset** pointed at `http://loki.logging:3100`,
+  - the **`kubernetes/logs` toolset disabled** (so Holmes uses Loki and sees pre-deploy history),
+  - **GitHub** read (to inspect the deploy's commit), and **Slack**.
+- ArgoCD does **not** need to be pre-installed — `install.sh` installs a dedicated instance.
+- A dedicated Git branch ArgoCD tracks (created from a branch that already contains this folder).
+
+## One-time setup
+
+1. **Build + push the images** (maintainer step):
+   ```bash
+   ./build.sh   # builds + pushes checkout-api:v1 and :v2
+   ```
+2. **Install everything** (ArgoCD → `argocd-demo`, Loki → `logging`, app → `checkout`):
+   ```bash
+   ./install.sh
+   # or wire Holmes in at the same time:
+   WEBHOOK_URL="https://<holmes-triggered-workflow>" WEBHOOK_TOKEN="<token>" ./install.sh
+   ```
+3. **Create the branch ArgoCD tracks** (separate from `main`). Create it from a branch that
+   already contains `argocd-log-analysis-demo/`:
+   ```bash
+   git checkout -b argocd-log-analysis-demo-live main
+   git push -u origin argocd-log-analysis-demo-live
+   ```
+   > Until this folder is merged into `main`, branch from wherever it currently lives instead.
+4. Configure the Triggered Workflow in Holmes with the prompt in
+   [`triggered-workflow-prompt.txt`](./triggered-workflow-prompt.txt).
+5. **Confirm baseline healthy:**
+   ```bash
+   kubectl get applications -n argocd-demo checkout   # Synced / Healthy
+   kubectl get pods -n checkout                       # checkout-api Running (2/2 with sidecar)
+   kubectl get pods -n logging                        # loki Running
+   ```
+
+## Running the demo
+
+On the live branch, ship the new version — a one-line image-tag bump:
+
+```bash
+git checkout argocd-log-analysis-demo-live
+# in gitops/manifest.yaml, change the checkout-api image:
+#   image: .../checkout-api:v2     # was :v1
+git commit -am "deploy checkout-api v2"
+git push
+```
+
+ArgoCD auto-syncs → `checkout-api` rolls out to `:v2` (pods stay healthy) → the
+`on-sync-succeeded` webhook fires → Holmes compares Loki logs before/after and posts to
+`#argocd-deploys`: it flags the **new pricing exception** (despite `200`s) as the real issue,
+calls the deprecation warning **noise**, and recognizes the recurring cache-miss warning as
+**pre-existing**.
+
+## Re-running the demo
+
+Reset to green by **reverting** the bump (keeps the demo files on the branch):
+
+```bash
+git checkout argocd-log-analysis-demo-live
+git revert --no-edit HEAD
+git push
+```
+
+ArgoCD self-heals back to `:v1`. Re-run by bumping to `:v2` again.
+
+## Cleanup
+
+```bash
+./install.sh --uninstall
+```
+
+Removes the `checkout`, `logging`, and `argocd-demo` namespaces. It leaves ArgoCD's
+cluster-scoped resources in place (they may be shared with another ArgoCD); the script prints
+the optional commands to remove those too.
+
+## How it works
+
+```
+git bump image :v1→:v2 ─▶ ArgoCD auto-sync ─▶ on-sync-succeeded webhook
+   └▶ Holmes Triggered Workflow
+        ├─ query Loki for this app's logs before vs after the deploy (re-query if needed; no sleep)
+        ├─ diff new-version lines vs the previous pod's baseline
+        ├─ classify each new line; infer business impact from errors
+        └▶ post to #argocd-deploys (clean / noise+✅ / full RCA)
+```
+
+The new version emits its logs immediately on startup and every ~2s, and the promtail sidecar
+batches at 100ms, so the new lines are in Loki within seconds — Holmes polls Loki rather than
+waiting.
+
+## Files
+
+- `build.sh`, `app/` — the `checkout-api` source built into `:v1` (healthy) and `:v2` (regressed).
+- `loki/loki.yaml` — minimal single-binary Loki (namespace `logging`).
+- `install.sh` — installs ArgoCD + Loki + the app; `--uninstall` to tear down.
+- `gitops/manifest.yaml` — the app Deployment (image tag bumped on deploy) + promtail sidecar + Service.
+- `argocd/application.yaml`, `argocd/notifications.yaml` — the ArgoCD app + Holmes webhook wiring.
+- `triggered-workflow-prompt.txt` — the Holmes log-analysis prompt (3 output modes).

--- a/argocd-log-analysis-demo/app/Dockerfile
+++ b/argocd-log-analysis-demo/app/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# The version is baked in at build time (no runtime env/flag), so the running
+# container exposes nothing that marks it as a demo — only the image tag differs.
+ARG VERSION=1
+RUN echo "VERSION = \"${VERSION}\"" > /app/version.py
+
+COPY app.py /app/app.py
+
+EXPOSE 8080
+CMD ["python", "/app/app.py"]

--- a/argocd-log-analysis-demo/app/app.py
+++ b/argocd-log-analysis-demo/app/app.py
@@ -1,0 +1,128 @@
+"""checkout-api — a tiny service that stays healthy but whose logs tell the real story.
+
+It serves /healthz (always 200) and continuously simulates checkout requests, writing
+structured JSON logs to /var/log/app.log (shipped to Loki by a promtail sidecar).
+
+The behavior differs between built image versions (baked in at build time via version.py —
+there is no runtime flag):
+  v1  → normal traffic + a recurring benign cache-miss WARN
+  v2  → same, plus a deprecated-config WARN (noise) and an intermittent unhandled exception
+        in the pricing path. The request handler catches it and still returns 200, so the
+        pod looks perfectly healthy — only the logs reveal that order totals are breaking.
+"""
+
+import json
+import os
+import socket
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+try:
+    from version import VERSION
+except Exception:
+    VERSION = "1"
+
+SERVICE = "checkout-api"
+POD = os.environ.get("HOSTNAME", socket.gethostname())
+LOG_PATH = "/var/log/app.log"
+
+_logfile = open(LOG_PATH, "a", buffering=1)
+
+
+def log(level, message, **fields):
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "level": level,
+        "service": SERVICE,
+        "pod": POD,
+        "message": message,
+    }
+    record.update(fields)
+    line = json.dumps(record)
+    _logfile.write(line + "\n")
+    print(line, flush=True)  # also to stdout for `kubectl logs`
+
+
+def lookup_price(order_id, seq):
+    # v2 regression: the new catalog client returns None for some items.
+    if VERSION == "2" and seq % 2 == 0:
+        return None
+    return 4999  # cents
+
+
+def compute_total(order_id, seq):
+    price = lookup_price(order_id, seq)
+    quantity = 3
+    return price * quantity  # raises TypeError when price is None (v2)
+
+
+def handle_checkout(order_id, seq):
+    """Simulate handling one checkout request. Always returns 200 to the caller."""
+    log("INFO", "received checkout request", order_id=order_id, endpoint="/api/checkout")
+    try:
+        total = compute_total(order_id, seq)
+        log("INFO", "checkout completed", order_id=order_id,
+            endpoint="/api/checkout", http_status=200, total_cents=total)
+    except Exception as exc:  # noqa: BLE001 - the handler swallows it and still answers 200
+        log("ERROR", "unhandled exception computing order total", order_id=order_id,
+            endpoint="/api/checkout", http_status=200,
+            error=f"{type(exc).__name__}: {exc}", loc="pricing.py:54")
+    return 200
+
+
+def traffic_loop():
+    log("INFO", "checkout-api starting", version=VERSION)
+    if VERSION == "2":
+        # surface the new-version log lines immediately, not only after warmup
+        log("WARN", "config key 'legacy_timeout' is deprecated; ignoring",
+            config_key="legacy_timeout")
+
+    seq = 0
+    order = 1000
+    while True:
+        seq += 1
+        order += 1
+        order_id = f"ord-{order}"
+
+        # pre-existing benign warning — present in BOTH v1 and v2
+        if seq % 5 == 0:
+            log("WARN", "cache miss for catalog entry, using slow path",
+                cache_key=f"sku-{(order % 900) + 100}")
+
+        # new noise — v2 only, harmless
+        if VERSION == "2" and seq % 20 == 0:
+            log("WARN", "config key 'legacy_timeout' is deprecated; ignoring",
+                config_key="legacy_timeout")
+
+        handle_checkout(order_id, seq)
+        time.sleep(2)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/healthz":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+        elif self.path == "/api/checkout":
+            handle_checkout(f"req-{int(time.time())}", int(time.time()))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):
+        pass  # silence default access logging; we emit our own JSON logs
+
+
+def main():
+    threading.Thread(target=traffic_loop, daemon=True).start()
+    ThreadingHTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/argocd-log-analysis-demo/app/requirements.txt
+++ b/argocd-log-analysis-demo/app/requirements.txt
@@ -1,0 +1,1 @@
+# checkout-api uses only the Python standard library — no dependencies.

--- a/argocd-log-analysis-demo/argocd/application.yaml
+++ b/argocd-log-analysis-demo/argocd/application.yaml
@@ -1,0 +1,29 @@
+# ArgoCD Application that watches the gitops/ folder and auto-syncs it.
+#
+# Replace the placeholders before applying (install.sh does this for you):
+#   __REPO_URL__        e.g. https://github.com/robusta-dev/kubernetes-demos
+#   __LIVE_BRANCH__     the dedicated branch ArgoCD tracks (NOT main), where the
+#                       image-tag bump is made on camera, e.g. argocd-log-analysis-demo-live
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: checkout
+  namespace: argocd-demo
+  annotations:
+    # Send a webhook to Holmes every time a new revision is successfully synced.
+    notifications.argoproj.io/subscribe.on-sync-succeeded.holmes: ""
+spec:
+  project: default
+  source:
+    repoURL: __REPO_URL__
+    path: argocd-log-analysis-demo/gitops
+    targetRevision: __LIVE_BRANCH__
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: checkout
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/argocd-log-analysis-demo/argocd/notifications.yaml
+++ b/argocd-log-analysis-demo/argocd/notifications.yaml
@@ -1,0 +1,45 @@
+# Wires ArgoCD's notifications controller to call the Holmes Triggered Workflow
+# webhook whenever a revision is synced.
+#
+# Replace the placeholders before applying (install.sh does this for you):
+#   __WEBHOOK_URL__     the Holmes Triggered Workflow endpoint
+#   __WEBHOOK_TOKEN__   the auth token for that endpoint
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd-demo
+data:
+  service.webhook.holmes: |
+    url: __WEBHOOK_URL__
+    headers:
+    - name: Authorization
+      value: Bearer $holmes-webhook-token
+    - name: Content-Type
+      value: application/json
+
+  trigger.on-sync-succeeded: |
+    - when: app.status.operationState.phase in ['Succeeded']
+      oncePer: app.status.sync.revision
+      send: [holmes-regression]
+
+  template.holmes-regression: |
+    webhook:
+      holmes:
+        method: POST
+        body: |
+          {
+            "app": "{{.app.metadata.name}}",
+            "revision": "{{.app.status.sync.revision}}",
+            "repoURL": "{{.app.spec.source.repoURL}}",
+            "namespace": "{{.app.spec.destination.namespace}}"
+          }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-notifications-secret
+  namespace: argocd-demo
+type: Opaque
+stringData:
+  holmes-webhook-token: __WEBHOOK_TOKEN__

--- a/argocd-log-analysis-demo/build.sh
+++ b/argocd-log-analysis-demo/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Build + push both image versions of checkout-api.
+#   :v1 = healthy baseline
+#   :v2 = same, plus the new-version noise + the pricing regression
+set -euo pipefail
+
+IMAGE="${IMAGE:-europe-docker.pkg.dev/robusta-development/kubernetes-demos/checkout-api}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/app"
+
+docker buildx build --platform linux/amd64 --push --build-arg VERSION=1 "${DIR}" -t "${IMAGE}:v1"
+docker buildx build --platform linux/amd64 --push --build-arg VERSION=2 "${DIR}" -t "${IMAGE}:v2"
+
+echo "Pushed ${IMAGE}:v1 and ${IMAGE}:v2"

--- a/argocd-log-analysis-demo/gitops/manifest.yaml
+++ b/argocd-log-analysis-demo/gitops/manifest.yaml
@@ -1,0 +1,136 @@
+# Desired state ArgoCD syncs: the checkout-api service (healthy baseline, image :v1) plus a
+# promtail sidecar that ships its JSON logs to Loki.
+#
+# The demo "deploy" is a one-line change here: bump the image tag :v1 -> :v2 and push.
+# Pods stay healthy; only the logs change.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: checkout
+data:
+  promtail-config.yaml: |
+    server:
+      http_listen_port: 9080
+    positions:
+      filename: /tmp/positions.yaml
+    clients:
+      - url: http://loki.logging:3100/loki/api/v1/push
+        batchwait: 100ms
+        batchsize: 102400
+    scrape_configs:
+      - job_name: checkout-api
+        static_configs:
+          - targets: [localhost]
+            labels:
+              job: checkout-api
+              namespace: checkout
+              __path__: /var/log/*.log
+        pipeline_stages:
+          - json:
+              expressions:
+                timestamp: timestamp
+                level: level
+                message: message
+                service: service
+                pod: pod
+          - timestamp:
+              source: timestamp
+              format: RFC3339
+          - labels:
+              level:
+              service:
+              pod:
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-api
+  namespace: checkout
+  labels:
+    app.kubernetes.io/name: checkout-api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: storefront
+    app.kubernetes.io/managed-by: argocd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: checkout-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: checkout-api
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: storefront
+    spec:
+      containers:
+      - name: checkout-api
+        image: europe-docker.pkg.dev/robusta-development/kubernetes-demos/checkout-api:v1
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        volumeMounts:
+        - name: logs
+          mountPath: /var/log
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+      - name: promtail
+        image: grafana/promtail:2.9.0
+        args:
+        - -config.file=/etc/promtail/promtail-config.yaml
+        volumeMounts:
+        - name: promtail-config
+          mountPath: /etc/promtail
+        - name: logs
+          mountPath: /var/log
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
+      volumes:
+      - name: logs
+        emptyDir: {}
+      - name: promtail-config
+        configMap:
+          name: promtail-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout-api
+  namespace: checkout
+  labels:
+    app.kubernetes.io/name: checkout-api
+    app.kubernetes.io/part-of: storefront
+spec:
+  selector:
+    app.kubernetes.io/name: checkout-api
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/argocd-log-analysis-demo/install.sh
+++ b/argocd-log-analysis-demo/install.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# One-command setup for the ArgoCD + Loki log-analysis demo.
+#
+# Installs (all into dedicated namespaces so nothing clashes with existing infra):
+#   - ArgoCD            -> namespace argocd-demo (default)
+#   - Loki              -> namespace logging
+#   - the checkout app  -> namespace checkout (deployed by ArgoCD)
+#
+# Usage:
+#   ./install.sh
+#   WEBHOOK_URL="https://<holmes-triggered-workflow>" WEBHOOK_TOKEN="<token>" ./install.sh
+#   ./install.sh --uninstall
+#
+# Override via env vars (see defaults below).
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-argocd-demo}"
+ARGOCD_VERSION="${ARGOCD_VERSION:-v3.4.4}"
+REPO_URL="${REPO_URL:-https://github.com/robusta-dev/kubernetes-demos}"
+LIVE_BRANCH="${LIVE_BRANCH:-argocd-log-analysis-demo-live}"
+WEBHOOK_URL="${WEBHOOK_URL:-}"
+WEBHOOK_TOKEN="${WEBHOOK_TOKEN:-}"
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_URL="https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml"
+
+# --- uninstall ---------------------------------------------------------------
+if [[ "${1:-}" == "--uninstall" || "${1:-}" == "uninstall" ]]; then
+  echo "==> Uninstalling demo (app, Loki, ArgoCD namespace '${NAMESPACE}')"
+  kubectl delete application checkout -n "${NAMESPACE}" --ignore-not-found
+  kubectl delete namespace checkout --ignore-not-found
+  kubectl delete namespace logging --ignore-not-found
+  kubectl delete namespace "${NAMESPACE}" --ignore-not-found
+  cat <<EOF
+
+==> Done. The dedicated namespaces are gone.
+
+ArgoCD's cluster-scoped resources were left in place (they may be shared with
+another ArgoCD on this cluster). If this was the ONLY ArgoCD, remove them with:
+
+  kubectl delete clusterrole argocd-application-controller argocd-server argocd-applicationset-controller --ignore-not-found
+  kubectl delete clusterrolebinding argocd-application-controller argocd-server argocd-applicationset-controller --ignore-not-found
+  kubectl delete crd applications.argoproj.io appprojects.argoproj.io applicationsets.argoproj.io --ignore-not-found
+EOF
+  exit 0
+fi
+# -----------------------------------------------------------------------------
+
+echo "==> Installing ArgoCD ${ARGOCD_VERSION} into namespace '${NAMESPACE}'"
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+# ArgoCD core (incl. notifications controller). Rewrite the hardcoded 'namespace: argocd'
+# refs to our namespace, and use server-side apply (the ApplicationSet CRD exceeds the
+# client-side annotation size limit).
+curl -sSL "${INSTALL_URL}" \
+  | sed "s|namespace: argocd$|namespace: ${NAMESPACE}|g" \
+  | kubectl apply --server-side --force-conflicts -n "${NAMESPACE}" -f -
+
+echo "==> Waiting for ArgoCD to become ready"
+kubectl wait --for=condition=established --timeout=60s crd/applications.argoproj.io
+for d in argocd-server argocd-repo-server argocd-notifications-controller; do
+  kubectl rollout status "deploy/${d}" -n "${NAMESPACE}" --timeout=300s
+done
+kubectl rollout status statefulset/argocd-application-controller -n "${NAMESPACE}" --timeout=300s
+
+echo "==> Installing Loki (namespace logging)"
+kubectl apply -f "${DIR}/loki/loki.yaml"
+kubectl rollout status deploy/loki -n logging --timeout=180s
+
+echo "==> Deploying demo Application (repo=${REPO_URL}, branch=${LIVE_BRANCH})"
+sed -e "s|__REPO_URL__|${REPO_URL}|g" \
+    -e "s|__LIVE_BRANCH__|${LIVE_BRANCH}|g" \
+    -e "s|namespace: argocd-demo|namespace: ${NAMESPACE}|g" \
+    "${DIR}/argocd/application.yaml" | kubectl apply -f -
+
+if [[ -n "${WEBHOOK_URL}" && -n "${WEBHOOK_TOKEN}" ]]; then
+  echo "==> Applying Holmes notification wiring"
+  sed -e "s|__WEBHOOK_URL__|${WEBHOOK_URL}|g" \
+      -e "s|__WEBHOOK_TOKEN__|${WEBHOOK_TOKEN}|g" \
+      -e "s|namespace: argocd-demo|namespace: ${NAMESPACE}|g" \
+      "${DIR}/argocd/notifications.yaml" | kubectl apply -f -
+else
+  echo "==> Skipping notification wiring (set WEBHOOK_URL and WEBHOOK_TOKEN to enable)"
+fi
+
+cat <<EOF
+
+==> Done. Confirm with:
+
+  kubectl get pods -n ${NAMESPACE}
+  kubectl get pods -n logging
+  kubectl get applications -n ${NAMESPACE} checkout
+  kubectl get pods -n checkout
+
+Point HolmesGPT's grafana/loki toolset at:  http://loki.logging:3100
+(and disable the kubernetes/logs toolset so Holmes uses Loki for history).
+
+ArgoCD UI (optional):
+  kubectl -n ${NAMESPACE} get secret argocd-initial-admin-secret -o jsonpath='{.data.password}'; echo
+  kubectl port-forward svc/argocd-server -n ${NAMESPACE} 8080:443   # https://localhost:8080 (user: admin)
+EOF

--- a/argocd-log-analysis-demo/loki/loki.yaml
+++ b/argocd-log-analysis-demo/loki/loki.yaml
@@ -1,0 +1,103 @@
+# Minimal single-binary Loki for the demo (no persistence, no auth, long lookback so
+# pre-deploy logs stay queryable). Adapted from the HolmesGPT test fixtures.
+# Service is reachable in-cluster at http://loki.logging:3100
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+      - name: loki
+        image: grafana/loki:2.9.0
+        args:
+        - -config.file=/etc/loki/loki-config.yaml
+        ports:
+        - containerPort: 3100
+          name: http
+        volumeMounts:
+        - name: config
+          mountPath: /etc/loki
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "10m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+      volumes:
+      - name: config
+        configMap:
+          name: loki-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: logging
+spec:
+  selector:
+    app: loki
+  ports:
+  - port: 3100
+    targetPort: 3100
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: logging
+data:
+  loki-config.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+    ingester:
+      query_store_max_look_back_period: -1
+      max_chunk_age: 17520h
+      wal:
+        enabled: false
+      lifecycler:
+        address: 127.0.0.1
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+        final_sleep: 0s
+    chunk_store_config:
+      max_look_back_period: 17520h
+    schema_config:
+      configs:
+        - from: 2020-01-01
+          store: boltdb
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 168h
+    storage_config:
+      boltdb:
+        directory: /tmp/loki/index
+      filesystem:
+        directory: /tmp/loki/chunks
+    limits_config:
+      enforce_metric_name: false
+      reject_old_samples: false
+      reject_old_samples_max_age: 104w
+      max_entries_limit_per_query: 5000
+      max_query_lookback: 17520h

--- a/argocd-log-analysis-demo/triggered-workflow-prompt.txt
+++ b/argocd-log-analysis-demo/triggered-workflow-prompt.txt
@@ -1,0 +1,92 @@
+You have received a JSON payload from an ArgoCD sync notification, and you are connected to a Kubernetes cluster (kubectl), to Loki (the grafana/loki toolset), and to GitHub (read). A new revision of an application was just deployed. The pods may look perfectly healthy (Running, passing health checks) — your job is to read the LOGS and decide whether the new version introduced a problem, then post one summary to Slack.
+
+The payload contains:
+- app        — the ArgoCD Application name
+- revision   — the synced Git commit SHA
+- repoURL    — the Git repository
+- namespace  — the namespace the app deploys into
+
+How to investigate:
+1. Query Loki for this application's logs in `namespace` over roughly the last 30 minutes. You should see logs from BOTH the previous pod (before the deploy) and the new pod (after it). If the new pod's logs aren't ingested yet, **query again** — do NOT sleep or wait; just re-run the query a few times until the new pod's lines appear.
+2. Diff the two: find the log lines (by message, ignoring variable values like ids/timestamps) that appear in the NEW version but were NOT present before. Lines present both before and after are pre-existing — do not report them as new.
+3. Classify each NEW line:
+   - noise — harmless (deprecation notices, cosmetic warnings, transient-and-recovered messages).
+   - critical — indicates a real problem. **Infer the business impact from the symptom**; the logs show symptoms, not conclusions (e.g. an exception in a request path while the request still returns `200` means the work is silently failing even though the service looks healthy).
+4. Optionally fetch the diff for `revision` from `repoURL` to confirm what changed in this deploy (e.g. an image-tag bump).
+5. Post ONE message to the `#argocd-deploys` Slack channel, choosing the matching mode below. Output Slack mrkdwn only; wrap every identifier in `inline code`.
+
+--
+# Output modes
+
+## Mode A — no new errors (clean)
+One line, nothing else:
+````
+🔍 *HolmesGPT — `<app>` @ `<short-revision>`:* clean deploy, no new errors in the logs (<short reason>).
+````
+
+## Mode B — new log lines, but only noise
+List the new lines as bullets with a one-line summary and a green check. No Evidence/Next Steps/closing question.
+````
+🔍 *HolmesGPT — `<app>` @ `<short-revision>`* ✅
+_New log lines since the deploy — all noise, no action needed:_
+• `<new line / message>` — <why it's harmless>
+• `<new line / message>` — <why it's harmless>
+*Summary:* <one line — what showed up and why it's safe to ignore>.
+````
+
+## Mode C — a real issue (full RCA)
+````
+🔍 *Automated RCA from HolmesGPT*
+_Triggered by ArgoCD sync of `<app>` @ `<short-revision>`_
+<https://platform.robusta.dev/holmes/triggered-workflows|View full investigation>
+
+*Triaged: <Urgent|High|Medium|Low>* <icon>
+
+*TL;DR:* <one-sentence verdict — what the new version is silently doing wrong, and the impact>
+
+*Evidence*
+• <Label> — <finding; identifiers in `inline code`>
+• New since deploy — this line appears only after the rollout (not in the previous version):
+```
+<the offending log line(s) — keep code blocks LAST in the section>
+```
+
+*Next Steps*
+1. <action>
+2. <action>
+
+<Closing question — ALWAYS end with one.>
+````
+
+# Rules
+- **View full investigation:** link to the full Holmes investigation for this run if you can resolve its URL; otherwise keep the link but point it at `https://platform.robusta.dev/holmes/triggered-workflows`.
+- **Priority** (Mode C): `*Triaged: <priority>*` with fixed icons — Urgent ‼️ · High ⏫ · Medium 🔼 · Low 🔽. Base it on blast radius / business impact.
+- **Inline code:** wrap deployment / service / pod / namespace names, image tags, commit SHAs, log levels, metrics, and thresholds in `inline code`.
+- **Evidence (Mode C):** lead each bullet with a short label; state what a snippet is and that it's new-since-the-deploy before showing it; put snippets last; never begin a line with inline code; trim to the lines that matter.
+- **Closing question (Mode C only):** end with a question on its own line. If you can open a PR with a fix/rollback, open it and reference it ("`PR #NN` … ready for your review — want me to change anything before you merge?"). If you cannot open a PR, do NOT say so — instead offer ("Want me to open a PR rolling back to the previous image tag?"); only if asked to proceed and you cannot, explain then. Never imply you can merge, apply, or roll out a change.
+- Modes A and B have no closing question.
+- Concise and direct. No Root Cause/Fix/Impact/Conclusion headers in Mode C — only TL;DR → Evidence → Next Steps → question.
+
+# Example — Mode C (illustrative, a different app from this demo)
+````
+🔍 *Automated RCA from HolmesGPT*
+_Triggered by ArgoCD sync of `payments` @ `7f3c901`_
+<https://platform.robusta.dev/holmes/triggered-workflows|View full investigation>
+
+*Triaged: High* ⏫
+
+*TL;DR:* The new `payments` build looks healthy (pods Ready, requests return `200`), but its logs show the refund path is throwing on every call — refunds are silently failing while the API reports success.
+
+*Evidence*
+• Healthy on the surface — `payments` pods `1/1` Ready, `/healthz` green, no restarts
+• New since deploy — this error appears only after `7f3c901`, on requests that still return `200`:
+```
+ERROR processing refund | KeyError: 'gateway_ref' | refunds.py:88 | http_status=200
+```
+
+*Next Steps*
+1. Roll `payments` back to the previous image tag
+2. Reconcile refunds attempted since the rollout
+
+Want me to open a PR rolling back `payments` to the previous tag?
+````


### PR DESCRIPTION
A demo of HolmesGPT catching a problem that **health checks can't see**: a new version deploys, the pods are Running and `/healthz` is green — but the **logs** show the new build is silently failing. ArgoCD's `on-sync-succeeded` webhook starts a Holmes Triggered Workflow that compares **Loki logs before vs after** the deploy and classifies what changed.

### Why Loki
After a deploy the old pods are gone, so only centralized logs retain the *pre-deploy* baseline — that's what lets Holmes distinguish "this error is new" from "that was already there."

### Contents (`argocd-log-analysis-demo/`)
- `app/` + `build.sh` — a small real `checkout-api` built into two image tags. `:v1` healthy; `:v2` keeps returning `200` but its pricing path throws on ~half of orders (totals silently break), plus a harmless new deprecation warning. The v1/v2 difference is baked in at build time (`ARG VERSION`), so **there's no runtime flag** for Holmes to flag as a test app — the deploy is an honest image-tag bump.
- `loki/loki.yaml` — minimal single-binary Loki (recycled from the HolmesGPT test fixtures), namespace `logging`.
- `gitops/manifest.yaml` — the `checkout-api` Deployment (image tag = the thing bumped on deploy) + a promtail sidecar shipping JSON logs to Loki + Service.
- `install.sh` — installs ArgoCD + Loki + the app into dedicated namespaces; `--uninstall` to tear down.
- `argocd/application.yaml` + `argocd/notifications.yaml` — the ArgoCD Application and `on-sync-succeeded` webhook wiring (recycled from `argocd-regression-demo`).
- `triggered-workflow-prompt.txt` — the Holmes log-analysis prompt with **three output modes**: clean one-liner / new-but-noise (bullets + ✅) / full RCA. It polls Loki (re-query) instead of sleeping, and infers business impact from symptoms.

### Three log classes the demo stages
- **pre-existing** (both v1 and v2): a recurring benign `cache miss … slow path` WARN.
- **new noise** (v2): `config key 'legacy_timeout' is deprecated`.
- **new critical** (v2): an unhandled pricing exception while the request still returns `200`.

### Notes
- Holmes prereqs: enable the `grafana/loki` toolset at `http://loki.logging:3100` and disable `kubernetes/logs` so it uses Loki history; GitHub read + Slack.
- Run/re-run uses `git revert` (not `reset --hard`), and the README leads with prerequisites.
- Generic throughout — no customer/competitor names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JEvpXJyVPG18eEoV8xYYk

---
_Generated by [Claude Code](https://claude.ai/code/session_018JEvpXJyVPG18eEoV8xYYk)_